### PR TITLE
[WIP] Retrieve end effector wrench

### DIFF
--- a/kortex2_driver/include/kortex2_driver/hardware_interface.hpp
+++ b/kortex2_driver/include/kortex2_driver/hardware_interface.hpp
@@ -71,7 +71,7 @@ private:
   k_api::RouterClient router_udp_realtime_;
   k_api::SessionManager session_manager_real_time_;
 
-  // Control of the robot arm itself
+  // Robot arm
   k_api::Base::BaseClient base_;
   k_api::BaseCyclic::BaseCyclicClient base_cyclic_;
   k_api::BaseCyclic::Command base_command_;
@@ -82,6 +82,7 @@ private:
   std::vector<double> arm_positions_;
   std::vector<double> arm_velocities_;
   std::vector<double> arm_efforts_;
+  std::vector<float> end_effector_force_;
   // Gripper
   k_api::GripperCyclic::MotorCommand* gripper_motor_command_;
   double gripper_command_position_;

--- a/kortex2_driver/src/hardware_interface.cpp
+++ b/kortex2_driver/src/hardware_interface.cpp
@@ -334,6 +334,12 @@ return_type KortexMultiInterfaceHardware::read()
         break;
     }
   }
+
+  end_effector_force_[0] = feedback.base().tool_external_wrench_force_x();
+  RCLCPP_INFO_STREAM(LOGGER, end_effector_force_[0]);
+  end_effector_force_[1] = feedback.base().tool_external_wrench_force_y();
+  end_effector_force_[2] = feedback.base().tool_external_wrench_force_z();
+
   return return_type::OK;
 }
 


### PR DESCRIPTION
It looks like there is an easy way to retrieve end-effector wrench from the Kortex API.

We should test this on hardware before continuing further with the PR.