### PR TITLE
Decrease ros2_control update_rate to 100 Hz

### DIFF
--- a/kortex2_bringup/config/kortex_controllers.yaml
+++ b/kortex2_bringup/config/kortex_controllers.yaml
@@ -1,6 +1,6 @@
 controller_manager:
   ros__parameters:
-    update_rate: 600  # Hz
+    update_rate: 100  # Hz
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster


### PR DESCRIPTION
Please test on hardware.

I believe this sets the spin rate of the main ros2_control loop. I don't think it will have a tangible effect on trajectories since they are all uploaded at once (maybe a small decrease in accuracy). I don't think it will affect Servo either -- it regulates its own publish rate.

Worth trying at least.