### PR TITLE
Update group name from `arm` to `manipulator`

### DIFF
--- a/kortex_move_it_config/gen3_robotiq_2f_85_move_it_config/config/7dof/gen3_robotiq_2f_85.srdf.xacro
+++ b/kortex_move_it_config/gen3_robotiq_2f_85_move_it_config/config/7dof/gen3_robotiq_2f_85.srdf.xacro
@@ -10,7 +10,7 @@
     <!--JOINTS - When a joint is specified, the child link of that joint (which will always exist) is automatically included-->
     <!--CHAINS - When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
     <!--SUBGROUPS - Groups can also be formed by referencing to already defined group names-->
-    <group name="arm">
+    <group name="manipulator">
         <joint name="$(arg prefix)joint_1" />
         <joint name="$(arg prefix)joint_2" />
         <joint name="$(arg prefix)joint_3" />
@@ -35,7 +35,7 @@
         <joint name="$(arg prefix)right_inner_finger_pad_joint" />
     </group>
     <!--GROUP STATES - Purpose - Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
-    <group_state name="home" group="arm">
+    <group_state name="home" group="manipulator">
         <joint name="$(arg prefix)joint_1" value="0" />
         <joint name="$(arg prefix)joint_2" value="0.26" />
         <joint name="$(arg prefix)joint_3" value="3.14" />
@@ -44,7 +44,7 @@
         <joint name="$(arg prefix)joint_6" value="0.96" />
         <joint name="$(arg prefix)joint_7" value="1.57" />
     </group_state>
-    <group_state name="retract" group="arm">
+    <group_state name="retract" group="manipulator">
         <joint name="$(arg prefix)joint_1" value="0" />
         <joint name="$(arg prefix)joint_2" value="-0.35" />
         <joint name="$(arg prefix)joint_3" value="3.14" />
@@ -53,7 +53,7 @@
         <joint name="$(arg prefix)joint_6" value="-0.87" />
         <joint name="$(arg prefix)joint_7" value="1.57" />
     </group_state>
-    <group_state name="vertical" group="arm">
+    <group_state name="vertical" group="manipulator">
         <joint name="$(arg prefix)joint_1" value="0" />
         <joint name="$(arg prefix)joint_2" value="0" />
         <joint name="$(arg prefix)joint_3" value="0" />

--- a/kortex_move_it_config/gen3_robotiq_2f_85_move_it_config/config/kinematics.yaml
+++ b/kortex_move_it_config/gen3_robotiq_2f_85_move_it_config/config/kinematics.yaml
@@ -1,4 +1,4 @@
-arm:
+manipulator:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005

--- a/kortex_move_it_config/gen3_robotiq_2f_85_move_it_config/config/ompl_planning.yaml
+++ b/kortex_move_it_config/gen3_robotiq_2f_85_move_it_config/config/ompl_planning.yaml
@@ -120,7 +120,7 @@ planner_configs:
     sparse_delta_fraction: 0.25  # delta fraction for connection distance. This value represents the visibility range of sparse samples. default: 0.25
     dense_delta_fraction: 0.001  # delta fraction for interface detection. default: 0.001
     max_failures: 5000  # maximum consecutive failure limit. default: 5000
-arm:
+manipulator:
   default_planner_config: RRTConnect
   planner_configs:
     - SBL


### PR DESCRIPTION
Manipulator was used in some places, arm in others. Studio was using `manipulator`. (You can check that at kortex2_bringup/config/gen3.srdf)

I noticed this by doing:  `ros2 param dump /move_group`. File attached. Notice that `arm` and `manipulator` are mixed
[move_group_rosparam.yaml.txt](https://github.com/PickNikRobotics/ros2_kortex/files/7009841/move_group_rosparam.yaml.txt)
