### PR TITLE
Simple twist-to-array republisher, to allow servoing with Kinova API

### DIFF
--- a/kortex2_hacks/CMakeLists.txt
+++ b/kortex2_hacks/CMakeLists.txt
@@ -1,0 +1,57 @@
+cmake_minimum_required(VERSION 3.5)
+project(kortex2_hacks)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(std_msgs REQUIRED)
+
+include_directories(include)
+
+# Subscribe to twist, convert to Float64MultiArray so we can jog the arm with the Kortex api
+# Create the main functionality in a way allowing it to be composable
+add_library(twist_to_array_republisher_lib SHARED
+            src/twist_to_array_republisher.cpp)
+target_compile_definitions(twist_to_array_republisher_lib
+  PRIVATE "MINIMAL_COMPOSITION_DLL")
+ament_target_dependencies(twist_to_array_republisher_lib rclcpp rclcpp_components geometry_msgs)
+
+# This package installs libraries without exporting them.
+# Export the library path to ensure that the installed libraries are available.
+if(NOT WIN32)
+  ament_environment_hooks(
+    "${ament_cmake_package_templates_ENVIRONMENT_HOOK_LIBRARY_PATH}")
+endif()
+
+# Executable for subscribing to twist, converting to Float64MultiArray so we can jog the arm with the Kortex api
+add_executable(twist_to_array_republisher_main src/twist_to_array_republisher_main.cpp)
+target_link_libraries(twist_to_array_republisher_main twist_to_array_republisher_lib)
+ament_target_dependencies(twist_to_array_republisher_main
+  rclcpp)
+
+install(TARGETS
+  twist_to_array_republisher_lib
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
+
+install(TARGETS
+  twist_to_array_republisher_main
+  DESTINATION lib/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/kortex2_hacks/include/kortex2_hacks/twist_to_array_republisher.hpp
+++ b/kortex2_hacks/include/kortex2_hacks/twist_to_array_republisher.hpp
@@ -12,6 +12,8 @@ public:
   TwistToArrayRepublisher(rclcpp::NodeOptions options);
 
 private:
+  void twistCallback(const geometry_msgs::msg::Twist::ConstPtr& twist_msg) const;
+
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_sub_;
   rclcpp::Publisher<std_msgs::msg::Float64MultiArray>::SharedPtr array_pub_;
 };

--- a/kortex2_hacks/include/kortex2_hacks/twist_to_array_republisher.hpp
+++ b/kortex2_hacks/include/kortex2_hacks/twist_to_array_republisher.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "rclcpp/rclcpp.hpp"
-#include "geometry_msgs/msg/twist.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
 #include "std_msgs/msg/float64_multi_array.hpp"
 
 namespace kortex2_hacks
@@ -12,10 +12,14 @@ public:
   TwistToArrayRepublisher(rclcpp::NodeOptions options);
 
 private:
-  void twistCallback(const geometry_msgs::msg::Twist::ConstPtr& twist_msg) const;
+  void twistCallback(const geometry_msgs::msg::TwistStamped::ConstPtr& twist_msg);
+  void timerCallback();
 
-  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_sub_;
   rclcpp::Publisher<std_msgs::msg::Float64MultiArray>::SharedPtr array_pub_;
+
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::Time last_user_msg_time_;
 };
 
 }  // namespace kortex2_hacks

--- a/kortex2_hacks/include/kortex2_hacks/twist_to_array_republisher.hpp
+++ b/kortex2_hacks/include/kortex2_hacks/twist_to_array_republisher.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "rclcpp/rclcpp.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+#include "std_msgs/msg/float64_multi_array.hpp"
+
+namespace kortex2_hacks
+{
+class TwistToArrayRepublisher : public rclcpp::Node
+{
+public:
+  TwistToArrayRepublisher(rclcpp::NodeOptions options);
+
+private:
+  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_sub_;
+  rclcpp::Publisher<std_msgs::msg::Float64MultiArray>::SharedPtr array_pub_;
+};
+
+}  // namespace kortex2_hacks

--- a/kortex2_hacks/package.xml
+++ b/kortex2_hacks/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>kortex2_hacks</name>
+  <version>0.0.0</version>
+  <description>Kinova-specific workarounds that are not pretty and should be rewritten ASAP.</description>
+  <maintainer email="zelenak@picknik.ai">Andy Zelenak</maintainer>
+  <license>Proprietary</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>geometry_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>std_msgs</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/kortex2_hacks/src/twist_to_array_republisher.cpp
+++ b/kortex2_hacks/src/twist_to_array_republisher.cpp
@@ -6,7 +6,7 @@ namespace kortex2_hacks
 namespace
 {
 constexpr char INCOMING_TWIST_TOPIC[] = "/twist_cmd";
-constexpr char OUTGOING_ARRAY_TOPIC[] = "/streaming_controller/command";
+constexpr char OUTGOING_ARRAY_TOPIC[] = "/streaming_controller/commands";
 }  // namespace
 
 TwistToArrayRepublisher::TwistToArrayRepublisher(rclcpp::NodeOptions options)

--- a/kortex2_hacks/src/twist_to_array_republisher.cpp
+++ b/kortex2_hacks/src/twist_to_array_republisher.cpp
@@ -5,32 +5,60 @@ namespace kortex2_hacks
 {
 namespace
 {
-constexpr char INCOMING_TWIST_TOPIC[] = "/twist_cmd";
+constexpr char INCOMING_TWIST_TOPIC[] = "/servo_server/delta_twist_cmds";
 constexpr char OUTGOING_ARRAY_TOPIC[] = "/streaming_controller/commands";
 }  // namespace
 
 TwistToArrayRepublisher::TwistToArrayRepublisher(rclcpp::NodeOptions options)
   : Node("twist_to_array_republisher", options)
 {
-  twist_sub_ = create_subscription<geometry_msgs::msg::Twist>(
+  twist_sub_ = create_subscription<geometry_msgs::msg::TwistStamped>(
       INCOMING_TWIST_TOPIC, 1, std::bind(&TwistToArrayRepublisher::twistCallback, this, std::placeholders::_1));
 
   array_pub_ = create_publisher<std_msgs::msg::Float64MultiArray>(OUTGOING_ARRAY_TOPIC, 1);
+
+  last_user_msg_time_ = rclcpp::Clock().now();
+
+  timer_ = this->create_wall_timer(std::chrono::milliseconds(200), 
+                                   std::bind(&TwistToArrayRepublisher::timerCallback, this));
 }
 
-void TwistToArrayRepublisher::twistCallback(const geometry_msgs::msg::Twist::ConstPtr& twist_msg) const
+void TwistToArrayRepublisher::timerCallback()
 {
+  if((rclcpp::Clock().now() - last_user_msg_time_).seconds() > 0.1)
+  {
+    std_msgs::msg::Float64MultiArray array_msg;
+    array_msg.data.resize(7);
+    array_msg.data[0] = 0.0;
+    array_msg.data[1] = 0.0;
+    array_msg.data[2] = 0.0;
+    array_msg.data[3] = 0.0;
+    array_msg.data[4] = 0.0;
+    array_msg.data[5] = 0.0;
+    array_msg.data[6] = 0.0;
+
+    array_pub_->publish(array_msg);
+    last_user_msg_time_ = rclcpp::Clock().now();
+  }
+}
+
+void TwistToArrayRepublisher::twistCallback(const geometry_msgs::msg::TwistStamped::ConstPtr& twist_msg)
+{
+  float scale_linear_mult = 0.07; // scale the incomming linear velocity commands
+  float scale_angular_mult = 4.0; // scale the incomming angular velocity commands
   // Convert twist to array
   std_msgs::msg::Float64MultiArray array_msg;
-  array_msg.data.resize(6);
-  array_msg.data[0] = twist_msg->linear.x;
-  array_msg.data[1] = twist_msg->linear.y;
-  array_msg.data[2] = twist_msg->linear.z;
-  array_msg.data[3] = twist_msg->angular.x;
-  array_msg.data[4] = twist_msg->angular.y;
-  array_msg.data[5] = twist_msg->angular.z;
+  array_msg.data.resize(7);
+  array_msg.data[0] = twist_msg->twist.linear.x * scale_linear_mult;
+  array_msg.data[1] = twist_msg->twist.linear.y * scale_linear_mult;
+  array_msg.data[2] = twist_msg->twist.linear.z * scale_linear_mult;
+  array_msg.data[3] = twist_msg->twist.angular.x * scale_angular_mult;
+  array_msg.data[4] = twist_msg->twist.angular.y * scale_angular_mult;
+  array_msg.data[5] = twist_msg->twist.angular.z * scale_angular_mult;
+  array_msg.data[6] = 0.0;
 
   array_pub_->publish(array_msg);
+  last_user_msg_time_ = rclcpp::Clock().now();
 }
 
 }  // namespace kortex2_hacks

--- a/kortex2_hacks/src/twist_to_array_republisher.cpp
+++ b/kortex2_hacks/src/twist_to_array_republisher.cpp
@@ -19,13 +19,13 @@ TwistToArrayRepublisher::TwistToArrayRepublisher(rclcpp::NodeOptions options)
 
   last_user_msg_time_ = rclcpp::Clock().now();
 
-  timer_ = this->create_wall_timer(std::chrono::milliseconds(200), 
-                                   std::bind(&TwistToArrayRepublisher::timerCallback, this));
+  timer_ =
+      this->create_wall_timer(std::chrono::milliseconds(200), std::bind(&TwistToArrayRepublisher::timerCallback, this));
 }
 
 void TwistToArrayRepublisher::timerCallback()
 {
-  if((rclcpp::Clock().now() - last_user_msg_time_).seconds() > 0.1)
+  if ((rclcpp::Clock().now() - last_user_msg_time_).seconds() > 0.1)
   {
     std_msgs::msg::Float64MultiArray array_msg;
     array_msg.data.resize(7);
@@ -44,8 +44,8 @@ void TwistToArrayRepublisher::timerCallback()
 
 void TwistToArrayRepublisher::twistCallback(const geometry_msgs::msg::TwistStamped::ConstPtr& twist_msg)
 {
-  float scale_linear_mult = 0.07; // scale the incomming linear velocity commands
-  float scale_angular_mult = 4.0; // scale the incomming angular velocity commands
+  float scale_linear_mult = 0.07;  // scale the incomming linear velocity commands
+  float scale_angular_mult = 4.0;  // scale the incomming angular velocity commands
   // Convert twist to array
   std_msgs::msg::Float64MultiArray array_msg;
   array_msg.data.resize(7);

--- a/kortex2_hacks/src/twist_to_array_republisher.cpp
+++ b/kortex2_hacks/src/twist_to_array_republisher.cpp
@@ -13,11 +13,24 @@ TwistToArrayRepublisher::TwistToArrayRepublisher(rclcpp::NodeOptions options)
   : Node("twist_to_array_republisher", options)
 {
   twist_sub_ = create_subscription<geometry_msgs::msg::Twist>(
-      INCOMING_TWIST_TOPIC, 1, [this](geometry_msgs::msg::Twist::UniquePtr msg) {
-        RCLCPP_INFO_STREAM(this->get_logger(), "Received this twist cmd: " << msg->linear.x);
-      });
+      INCOMING_TWIST_TOPIC, 1, std::bind(&TwistToArrayRepublisher::twistCallback, this, std::placeholders::_1));
 
   array_pub_ = create_publisher<std_msgs::msg::Float64MultiArray>(OUTGOING_ARRAY_TOPIC, 1);
+}
+
+void TwistToArrayRepublisher::twistCallback(const geometry_msgs::msg::Twist::ConstPtr& twist_msg) const
+{
+  // Convert twist to array
+  std_msgs::msg::Float64MultiArray array_msg;
+  array_msg.data.resize(6);
+  array_msg.data[0] = twist_msg->linear.x;
+  array_msg.data[1] = twist_msg->linear.y;
+  array_msg.data[2] = twist_msg->linear.z;
+  array_msg.data[3] = twist_msg->angular.x;
+  array_msg.data[4] = twist_msg->angular.y;
+  array_msg.data[5] = twist_msg->angular.z;
+
+  array_pub_->publish(array_msg);
 }
 
 }  // namespace kortex2_hacks

--- a/kortex2_hacks/src/twist_to_array_republisher.cpp
+++ b/kortex2_hacks/src/twist_to_array_republisher.cpp
@@ -1,0 +1,26 @@
+#include "kortex2_hacks/twist_to_array_republisher.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace kortex2_hacks
+{
+namespace
+{
+constexpr char INCOMING_TWIST_TOPIC[] = "/twist_cmd";
+constexpr char OUTGOING_ARRAY_TOPIC[] = "/streaming_controller/command";
+}  // namespace
+
+TwistToArrayRepublisher::TwistToArrayRepublisher(rclcpp::NodeOptions options)
+  : Node("twist_to_array_republisher", options)
+{
+  twist_sub_ = create_subscription<geometry_msgs::msg::Twist>(
+      INCOMING_TWIST_TOPIC, 1, [this](geometry_msgs::msg::Twist::UniquePtr msg) {
+        RCLCPP_INFO_STREAM(this->get_logger(), "Received this twist cmd: " << msg->linear.x);
+      });
+
+  array_pub_ = create_publisher<std_msgs::msg::Float64MultiArray>(OUTGOING_ARRAY_TOPIC, 1);
+}
+
+}  // namespace kortex2_hacks
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(kortex2_hacks::TwistToArrayRepublisher)

--- a/kortex2_hacks/src/twist_to_array_republisher_main.cpp
+++ b/kortex2_hacks/src/twist_to_array_republisher_main.cpp
@@ -2,15 +2,15 @@
 #include "kortex2_hacks/twist_to_array_republisher.hpp"
 #include "rclcpp/rclcpp.hpp"
 
+// Subscribe to twist, convert to Float64MultiArray so we can jog the arm with the Kortex api
+
 int main(int argc, char* argv[])
 {
   rclcpp::init(argc, argv);
   rclcpp::executors::SingleThreadedExecutor exec;
   rclcpp::NodeOptions options;
-  //  auto array_pub_node = std::make_shared<PublisherNode>(options);
-  auto twist_subscriber = std::make_shared<kortex2_hacks::TwistToArrayRepublisher>(options);
-  //  exec.add_node(array_pub_node);
-  exec.add_node(twist_subscriber);
+  auto twist_republisher = std::make_shared<kortex2_hacks::TwistToArrayRepublisher>(options);
+  exec.add_node(twist_republisher);
   exec.spin();
   rclcpp::shutdown();
   return 0;

--- a/kortex2_hacks/src/twist_to_array_republisher_main.cpp
+++ b/kortex2_hacks/src/twist_to_array_republisher_main.cpp
@@ -1,0 +1,17 @@
+#include <memory>
+#include "kortex2_hacks/twist_to_array_republisher.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char* argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::executors::SingleThreadedExecutor exec;
+  rclcpp::NodeOptions options;
+  //  auto array_pub_node = std::make_shared<PublisherNode>(options);
+  auto twist_subscriber = std::make_shared<kortex2_hacks::TwistToArrayRepublisher>(options);
+  //  exec.add_node(array_pub_node);
+  exec.add_node(twist_subscriber);
+  exec.spin();
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
You can easily test like this:

`ros2 run kortex2_hacks twist_to_array_republisher_main`

`rqt` -> start a Message Publisher plugin

Publish any test command to /twist_cmd. You should see a corresponding message on /streaming_controller/commands

After merging this, please review this moveit_studio PR to add it to the launch file:  https://github.com/PickNikRobotics/moveit_studio/pull/334