### PR TITLE
Enabled controller switching for Kinova Servo mode

### DIFF
--- a/kortex2_bringup/config/kortex_controllers.yaml
+++ b/kortex2_bringup/config/kortex_controllers.yaml
@@ -1,6 +1,6 @@
 controller_manager:
   ros__parameters:
-    update_rate: 600  # Hz
+    update_rate: 1000  # Hz
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
@@ -27,6 +27,7 @@ joint_trajectory_controller:
       - joint_7
     command_interfaces:
       - position
+      - velocity
     state_interfaces:
       - position
       - velocity

--- a/kortex2_bringup/config/servo.yaml
+++ b/kortex2_bringup/config/servo.yaml
@@ -52,7 +52,7 @@ cartesian_command_in_topic: ~/delta_twist_cmds  # Topic for incoming Cartesian t
 joint_command_in_topic: ~/delta_joint_cmds # Topic for incoming joint angle commands
 joint_topic: /joint_states
 status_topic: ~/status # Publish status to this topic
-command_out_topic: /joint_trajectory_controller/joint_trajectory # Publish outgoing commands here
+command_out_topic: /position_controller/joint_trajectory # Publish outgoing commands here
 
 ## Collision checking for the entire robot body
 check_collisions: true # Check collisions?

--- a/kortex2_driver/include/kortex2_driver/hardware_interface.hpp
+++ b/kortex2_driver/include/kortex2_driver/hardware_interface.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "rclcpp/macros.hpp"
+#include "rclcpp/time.hpp"
 
 #include "hardware_interface/base_interface.hpp"
 #include "hardware_interface/handle.hpp"
@@ -76,6 +77,8 @@ private:
   k_api::BaseCyclic::BaseCyclicClient base_cyclic_;
   k_api::BaseCyclic::Command base_command_;
   std::size_t actuator_count_;
+  // To minimize bandwidth we syncronize feedback with the robot only when write() is called
+  k_api::BaseCyclic::Feedback feedback_;
   std::vector<double> arm_commands_positions_;
   std::vector<double> arm_commands_velocities_;
   std::vector<double> arm_commands_efforts_;
@@ -86,6 +89,10 @@ private:
   k_api::GripperCyclic::MotorCommand* gripper_motor_command_;
   double gripper_command_position_;
   double gripper_position_;
+
+  rclcpp::Time controller_switch_time_;
+  bool block_write = false;
+  k_api::Base::ServoingMode arm_mode_;
 
   // Enum defining at which control level we are
   // Dumb way of maintaining the command_interface type per joint.

--- a/kortex2_driver/src/hardware_interface.cpp
+++ b/kortex2_driver/src/hardware_interface.cpp
@@ -60,7 +60,6 @@ KortexMultiInterfaceHardware::KortexMultiInterfaceHardware()
   servoing_mode.set_servoing_mode(k_api::Base::ServoingMode::LOW_LEVEL_SERVOING);
   base_.SetServoingMode(servoing_mode);
   actuator_count_ = base_.GetActuatorCount().count();
-  RCLCPP_INFO(LOGGER, "Actuator count: %u", actuator_count_);
 }
 
 return_type KortexMultiInterfaceHardware::configure(const hardware_interface::HardwareInfo& info)
@@ -81,7 +80,7 @@ return_type KortexMultiInterfaceHardware::configure(const hardware_interface::Ha
   arm_commands_efforts_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
   gripper_command_position_ = std::numeric_limits<double>::quiet_NaN();
   gripper_position_ = std::numeric_limits<double>::quiet_NaN();
-  arm_joints_control_level_.resize(info_.joints.size(), integration_lvl_t::POSITION);
+  arm_joints_control_level_.resize(info_.joints.size(), integration_lvl_t::UNDEFINED); // start in undefined
 
   for (const hardware_interface::ComponentInfo& joint : info_.joints)
   {
@@ -116,7 +115,7 @@ std::vector<hardware_interface::StateInterface> KortexMultiInterfaceHardware::ex
   std::vector<hardware_interface::StateInterface> state_interfaces;
   for (std::size_t i = 0; i < info_.joints.size(); i++)
   {
-    RCLCPP_WARN(LOGGER, "export_state_interfaces for joint: %s", info_.joints[i].name.c_str());
+    RCLCPP_DEBUG(LOGGER, "export_state_interfaces for joint: %s", info_.joints[i].name.c_str());
     if (info_.joints[i].name == "finger_joint")  // TODO find a better way to identify gripper joint(s)
     {
       state_interfaces.emplace_back(hardware_interface::StateInterface(
@@ -168,7 +167,7 @@ return_type KortexMultiInterfaceHardware::prepare_command_mode_switch(const std:
   std::vector<std::size_t> new_mode_joint_index = {};
   for (std::string key : start_interfaces)
   {
-    RCLCPP_DEBUG(LOGGER, "New command mode for joint: %s, total joints: %u", key.c_str(), info_.joints.size());
+    RCLCPP_DEBUG(LOGGER, "New command mode for joint: %s, total joints: %lu", key.c_str(), info_.joints.size());
     for (std::size_t i = 0; i < info_.joints.size(); i++)
     {
       if (key == info_.joints[i].name + "/" + hardware_interface::HW_IF_POSITION)
@@ -178,8 +177,15 @@ return_type KortexMultiInterfaceHardware::prepare_command_mode_switch(const std:
       }
       if (key == info_.joints[i].name + "/" + hardware_interface::HW_IF_VELOCITY)
       {
-        new_modes.push_back(integration_lvl_t::VELOCITY);
-        new_mode_joint_index.push_back(i);
+        if(new_mode_joint_index.back() == i)
+        {
+          new_modes.back() = integration_lvl_t::VELOCITY;
+        }
+        else
+        {
+          new_modes.push_back(integration_lvl_t::VELOCITY);
+          new_mode_joint_index.push_back(i);
+        }
       }
       if (key == info_.joints[i].name + "/" + hardware_interface::HW_IF_EFFORT)
       {
@@ -206,8 +212,62 @@ return_type KortexMultiInterfaceHardware::prepare_command_mode_switch(const std:
   // Set the new command modes
   for (std::size_t i = 0; i < new_modes.size(); i++)
   {
+    // if this interface is not free then we cant switch modes!
+    if(arm_joints_control_level_[new_mode_joint_index[i]] != integration_lvl_t::UNDEFINED)
+    {
+      RCLCPP_ERROR(LOGGER, "Attempting to start interface that is already claimed. Joint mode index: %ld, arm_joints_control_level_[%d]", 
+                  new_mode_joint_index[i], arm_joints_control_level_[new_mode_joint_index[i]]);
+      return return_type::ERROR;
+    }
     arm_joints_control_level_[new_mode_joint_index[i]] = new_modes[i];
-    RCLCPP_DEBUG(LOGGER, "arm_joints_control_level_[%d], mode: %u", new_mode_joint_index[i], new_modes[i]);
+    RCLCPP_DEBUG(LOGGER, "arm_joints_control_level_[%ld] mode: %u", new_mode_joint_index[i], new_modes[i]);
+  }
+
+  // TODO (marqrazz): NEED better way to detect that we are switching kinova servo mode!
+  // Current hack is that if the arm is in integration_lvl_t::VELOCITY then we using the `joint_trajectory_controller`
+  // if the arm is in integration_lvl_t::POSITION then we are using the `streaming_controller`
+  if(arm_joints_control_level_[6] == integration_lvl_t::VELOCITY && 
+     info_.joints[new_mode_joint_index.front()].name != "finger_joint")  // TODO find a better way to identify gripper joint(s)
+  {
+    block_write = true;
+    std::this_thread::sleep_for(std::chrono::milliseconds(50)); // sleep to ensure all outgoing write commands have finished
+    auto servoing_mode = k_api::Base::ServoingModeInformation();
+    // Set the base in low-level servoing mode    
+    arm_mode_ = k_api::Base::ServoingMode::LOW_LEVEL_SERVOING;
+    servoing_mode.set_servoing_mode(k_api::Base::ServoingMode::LOW_LEVEL_SERVOING);
+    base_.SetServoingMode(servoing_mode);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    feedback_ = base_cyclic_.RefreshFeedback();
+    for (std::size_t i = 0; i < actuator_count_; i++)
+    {
+      arm_commands_positions_[i] = KortexMathUtil::wrapRadiansFromMinusPiToPi(
+          KortexMathUtil::toRad(feedback_.actuators(i).position()));  // rad
+      // RCLCPP_ERROR(LOGGER, "setting joint[%ld] position: %f", i, arm_commands_positions_[i]);
+    }
+    RCLCPP_INFO(LOGGER, "Switching to LOW_LEVEL_SERVOING");
+    controller_switch_time_ = rclcpp::Clock().now();
+    block_write = false;
+  }
+  else if(arm_joints_control_level_[6] == integration_lvl_t::POSITION && 
+          info_.joints[new_mode_joint_index.front()].name != "finger_joint")  // TODO find a better way to identify gripper joint(s)
+  {
+    block_write = true;
+    std::this_thread::sleep_for(std::chrono::milliseconds(50)); // sleep to ensure all outgoing write commands have finished
+    auto servoing_mode = k_api::Base::ServoingModeInformation();
+    // Set the base in low-level servoing mode
+    arm_mode_ = k_api::Base::ServoingMode::SINGLE_LEVEL_SERVOING;
+    servoing_mode.set_servoing_mode(k_api::Base::ServoingMode::SINGLE_LEVEL_SERVOING);
+    base_.SetServoingMode(servoing_mode);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    feedback_ = base_cyclic_.RefreshFeedback();
+    for (std::size_t i = 0; i < actuator_count_; i++)
+    {
+      arm_commands_positions_[i] = 0.0;  // this is a twist command at this point
+      // RCLCPP_ERROR(LOGGER, "setting joint[%d] position: %f", i, arm_commands_positions_[i]);
+    }
+    RCLCPP_INFO(LOGGER, "Switching to SINGLE_LEVEL_SERVOING");
+    controller_switch_time_ = rclcpp::Clock().now();
+    block_write = false;
   }
 
   return return_type::OK;
@@ -215,6 +275,7 @@ return_type KortexMultiInterfaceHardware::prepare_command_mode_switch(const std:
 
 return_type KortexMultiInterfaceHardware::start()
 {
+  base_.ClearFaults();
   auto base_feedback = base_cyclic_.RefreshFeedback();
   // Add each actuator to the base_command_ and set the command to its current position
   for (std::size_t i = 0; i < actuator_count_; i++)
@@ -264,11 +325,10 @@ return_type KortexMultiInterfaceHardware::start()
       arm_commands_efforts_[i] = 0;
     }
     arm_joints_control_level_[i] = integration_lvl_t::UNDEFINED;
-    RCLCPP_INFO(LOGGER, "System successfully started! %u", i);
   }
   status_ = hardware_interface::status::STARTED;
 
-  RCLCPP_INFO(LOGGER, "System successfully started! %u", arm_joints_control_level_[0]);
+  RCLCPP_INFO(LOGGER, "System successfully started!");
   return return_type::OK;
 }
 
@@ -300,47 +360,91 @@ return_type KortexMultiInterfaceHardware::stop()
 
 return_type KortexMultiInterfaceHardware::read()
 {
-  auto feedback = base_cyclic_.RefreshFeedback();
   for (std::size_t i = 0; i < info_.joints.size(); i++)
   {
-    // RCLCPP_WARN(LOGGER, "Joint: %s", info_.joints[i].name.c_str());
     switch (arm_joints_control_level_[i])
     {
       case integration_lvl_t::UNDEFINED:
-        RCLCPP_INFO(LOGGER, "Nothing is using the hardware interface! %u", i);
+        // RCLCPP_INFO(LOGGER, "Nothing is using the hardware interface! %u", i);
         return return_type::OK;
         break;
-      case integration_lvl_t::POSITION:
+      default:
         if (info_.joints[i].name == "finger_joint")  // TODO find a better way to identify gripper joint(s)
         {
           // max joint angle = 0.81 for robotiq_2f_85
           // TODO read in as paramter from kortex_controllers.yaml
-          gripper_position_ = feedback.interconnect().gripper_feedback().motor()[0].position() / 100.0 * 0.81;  // rad
+          gripper_position_ = feedback_.interconnect().gripper_feedback().motor()[0].position() / 100.0 * 0.81;  // rad
         }
         else
         {
-          arm_efforts_[i] = feedback.actuators(i).torque();                              // N*m
-          arm_velocities_[i] = KortexMathUtil::toRad(feedback.actuators(i).velocity());  // rad/sec
-          arm_positions_[i] = KortexMathUtil::wrapRadiansFromMinusPiToPi(
-              KortexMathUtil::toRad(feedback.actuators(i).position()));  // rad
+          arm_efforts_[i] = feedback_.actuators(i).torque();                              // N*m
+          arm_velocities_[i] = KortexMathUtil::toRad(feedback_.actuators(i).velocity());  // rad/sec
+          int num_turns = 0;
+          arm_positions_[i] = KortexMathUtil::wrapRadiansFromMinusPiToPi(KortexMathUtil::toRad(feedback_.actuators(i).position()), num_turns);  // rad
         }
         break;
-      case integration_lvl_t::VELOCITY:
-        arm_efforts_[i] = feedback.actuators(i).torque();                              // N*m
-        arm_velocities_[i] = KortexMathUtil::toRad(feedback.actuators(i).velocity());  // rad/sec
-        break;
-      case integration_lvl_t::EFFORT:
-        arm_efforts_[i] = feedback.actuators(i).torque();  // N*m
-        break;
-    }
+    }    
   }
   return return_type::OK;
 }
 
 return_type KortexMultiInterfaceHardware::write()
 {
-  Kinova::Api::BaseCyclic::Feedback feedback;
-  gripper_motor_command_->set_position(gripper_command_position_);  // % position
+  if(block_write)
+  {
+    feedback_ = base_cyclic_.RefreshFeedback();
+    return return_type::OK;
+  }
+    
+  if(arm_mode_ == k_api::Base::ServoingMode::SINGLE_LEVEL_SERVOING)
+  {
+    // TODO (marqrazz): The command interface is not properly locking so when we switch controllers
+    // the last active controller is still sending commands to `arm_commands_positions_` which causes
+    // the arm to servo based on the old commands.
+    if((rclcpp::Clock().now() - controller_switch_time_).seconds() < 0.5)
+    {
+      feedback_ = base_cyclic_.RefreshFeedback();
+      for (std::size_t j = 0; j < actuator_count_; j++)
+      {
+        arm_commands_positions_[j] = 0.0;  // This is a twist command at this point
+      }
+      return return_type::OK;
+    }
+
+    auto command = k_api::Base::TwistCommand();
+    command.set_reference_frame(k_api::Common::CARTESIAN_REFERENCE_FRAME_TOOL);
+    // command.set_duration = execute time (milliseconds) according to the api -> (not implemented yet)
+    // see: https://github.com/Kinovarobotics/kortex/blob/master/api_cpp/doc/markdown/messages/Base/TwistCommand.md
+    command.set_duration(0);
+
+    auto twist = command.mutable_twist();
+    twist->set_linear_x(float(arm_commands_positions_[0]));
+    twist->set_linear_y(float(arm_commands_positions_[1]));
+    twist->set_linear_z(float(arm_commands_positions_[2]));
+    twist->set_angular_x(float(arm_commands_positions_[3]));
+    twist->set_angular_y(float(arm_commands_positions_[4]));
+    twist->set_angular_z(float(arm_commands_positions_[5]));
+    base_.SendTwistCommand(command);
+
+    k_api::Base::GripperCommand gripper_command;
+    gripper_command.set_mode(k_api::Base::GRIPPER_POSITION);
+    auto finger = gripper_command.mutable_gripper()->add_finger();
+    finger->set_finger_identifier(1);;
+    finger->set_value(gripper_command_position_/100.0); // This values needs to be between 0 and 1
+    base_.SendGripperCommand(gripper_command);
+
+    feedback_ = base_cyclic_.RefreshFeedback();
+    return return_type::OK;
+  }
+  if(arm_mode_ != k_api::Base::ServoingMode::LOW_LEVEL_SERVOING || 
+     feedback_.base().active_state()!= k_api::Common::ARMSTATE_SERVOING_LOW_LEVEL)
+  {
+    feedback_ = base_cyclic_.RefreshFeedback();
+    RCLCPP_DEBUG(LOGGER, " Arm is not in LOW_LEVEL_SERVOING mode");
+    return return_type::OK;
+  }
+
+  gripper_motor_command_->set_position(gripper_command_position_);  // % open/closed, this values needs to be between 0 and 1
   gripper_motor_command_->set_velocity(100.0);  // % speed TODO read in as paramter from kortex_controllers.yaml
   gripper_motor_command_->set_force(100.0);     // % torque TODO read in as paramter from kortex_controllers.yaml
 
@@ -352,18 +456,39 @@ return_type KortexMultiInterfaceHardware::write()
   // update the command for each joint
   for (std::size_t i = 0; i < actuator_count_; i++)
   {
-    float cmd_degrees = KortexMathUtil::wrapDegreesFromZeroTo360(KortexMathUtil::toDeg(arm_commands_positions_[i]));
+    float cmd_degrees = 0.0;
+
+    // TODO (marqrazz): The command interface is not properly locking so when we switch controllers
+    // the last active controller is still sending commands to `arm_commands_positions_` which causes
+    // the arm to jump because the command delta is large.
+    if(abs(arm_commands_positions_[i] - arm_positions_[i]) > 0.1 && (rclcpp::Clock().now() - controller_switch_time_).seconds() < 0.5)
+    {
+      RCLCPP_WARN(LOGGER, "Arms joint[%ld] command error is too large, setting command to current robot position. Error: %f. Command: %f, Actual: %f", i, 
+                  abs(arm_commands_positions_[i] - arm_positions_[i]),
+                  arm_commands_positions_[i], arm_positions_[i]);
+      feedback_ = base_cyclic_.RefreshFeedback();
+      for (std::size_t j = 0; j < actuator_count_; j++)
+      {
+        arm_commands_positions_[j] = KortexMathUtil::wrapRadiansFromMinusPiToPi(
+            KortexMathUtil::toRad(feedback_.actuators(j).position()));  // rad
+      }
+      return return_type::OK;
+    }
+    else
+    {
+      cmd_degrees = KortexMathUtil::wrapDegreesFromZeroTo360(KortexMathUtil::toDeg(arm_commands_positions_[i]));
+    }
     float cmd_vel = KortexMathUtil::toDeg(arm_commands_velocities_[i]);
 
     base_command_.mutable_actuators(i)->set_position(cmd_degrees);
-    base_command_.mutable_actuators(i)->set_velocity(cmd_vel);
+    // base_command_.mutable_actuators(i)->set_velocity(cmd_vel);  // This is currently not implemented properly in the kortex api
     base_command_.mutable_actuators(i)->set_command_id(base_command_.frame_id());
   }
 
   // send the command to the robot
   try
   {
-    feedback = base_cyclic_.Refresh(base_command_, 0);
+    feedback_ = base_cyclic_.Refresh(base_command_, 0);
   }
   catch (k_api::KDetailedException& ex)
   {
@@ -371,6 +496,11 @@ return_type KortexMultiInterfaceHardware::write()
 
     RCLCPP_ERROR_STREAM(LOGGER, "Error sub-code: " << k_api::SubErrorCodes_Name(
                                     k_api::SubErrorCodes((ex.getErrorInfo().getError().error_sub_code()))));
+
+    // attempt to clear any robot faults
+    base_.ClearFaults();
+    feedback_ = base_cyclic_.RefreshFeedback();
+    RCLCPP_WARN(LOGGER, "Attempting to clear faults. [base_active_state: %u]", feedback_.base().active_state());
   }
   return return_type::OK;
 }


### PR DESCRIPTION
The PR adds the ability to switch between `low_level_servo` mode for executing trajectories from Moveit to `single_level_servo` where the arm can be commanded by a twist message.