### PR TITLE
Limited shoulder to keep elbow up

### DIFF
--- a/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
+++ b/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
@@ -119,7 +119,7 @@
         link="${prefix}half_arm_1_link" />
       <axis
         xyz="0 0 1" />
-      <limit lower="-2.41" upper="2.41" effort="39" velocity="1.3963" />
+      <limit lower="-1.3" upper="1.3" effort="39" velocity="1.3963" />
     </joint>
     <link name="${prefix}half_arm_2_link">
       <inertial>

--- a/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
+++ b/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
@@ -119,7 +119,7 @@
         link="${prefix}half_arm_1_link" />
       <axis
         xyz="0 0 1" />
-      <limit lower="-1.3" upper="1.3" effort="39" velocity="1.3963" />
+      <limit lower="-1.4" upper="1.4" effort="39" velocity="1.3963" />
     </joint>
     <link name="${prefix}half_arm_2_link">
       <inertial>


### PR DESCRIPTION
This PR limits the shoulder from +-2.41 to +-1.3 to help keep the elbow up for the x-prize competition.