### PR TITLE
Move early exit when only stopping controllers

### DIFF
--- a/kortex2_driver/src/hardware_interface.cpp
+++ b/kortex2_driver/src/hardware_interface.cpp
@@ -209,9 +209,6 @@ return_type KortexMultiInterfaceHardware::prepare_command_mode_switch(const std:
       }
     }
   }
-  // If we are not starting anything we are done
-  if (new_modes.empty())
-    return return_type::OK;
 
   // if we are sending twist messages to Kinova and our controller controller is changing we need to ensure the arm is stopped!
   if (arm_mode_ == k_api::Base::ServoingMode::SINGLE_LEVEL_SERVOING &&
@@ -239,6 +236,10 @@ return_type KortexMultiInterfaceHardware::prepare_command_mode_switch(const std:
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
     block_write = false;
   }
+
+  // If we are not starting any controllers we are done
+  if (new_modes.empty())
+    return return_type::OK;
 
   // Set the new command modes
   for (std::size_t i = 0; i < new_modes.size(); i++)


### PR DESCRIPTION
This moves the early exit when we are only stopping controllers. This fixed a seg fault but we should also make sure we stop the twist controller.