### PR TITLE
Avoid joints near PI due to wraparound issue

### DIFF
--- a/kortex2_bringup/config/gen3.srdf
+++ b/kortex2_bringup/config/gen3.srdf
@@ -41,7 +41,7 @@
   <group_state group="manipulator" name="home">
     <joint name="joint_1" value="0"/>
     <joint name="joint_2" value="0.26"/>
-    <joint name="joint_3" value="3.14"/>
+    <joint name="joint_3" value="3.0"/>
     <joint name="joint_4" value="-2.27"/>
     <joint name="joint_5" value="0"/>
     <joint name="joint_6" value="0.96"/>
@@ -50,7 +50,7 @@
   <group_state group="manipulator" name="weigh">
     <joint name="joint_1" value="0"/>
     <joint name="joint_2" value="0"/>
-    <joint name="joint_3" value="3.14"/>
+    <joint name="joint_3" value="3.0"/>
     <joint name="joint_4" value="-2.27"/>
     <joint name="joint_5" value="0"/>
     <joint name="joint_6" value="0.7"/>
@@ -59,7 +59,7 @@
   <group_state group="manipulator" name="retract">
     <joint name="joint_1" value="0"/>
     <joint name="joint_2" value="-0.35"/>
-    <joint name="joint_3" value="3.14"/>
+    <joint name="joint_3" value="3.0"/>
     <joint name="joint_4" value="-2.54"/>
     <joint name="joint_5" value="0"/>
     <joint name="joint_6" value="-0.87"/>
@@ -86,7 +86,7 @@
   <group_state group="manipulator" name="puzzle">
     <joint name="joint_1" value="0.0"/>
     <joint name="joint_2" value="0.567"/>
-    <joint name="joint_3" value="-3.1"/>
+    <joint name="joint_3" value="-3.0"/>
     <joint name="joint_4" value="-0.68"/>
     <joint name="joint_5" value="-0.059"/>
     <joint name="joint_6" value="-1.904"/>


### PR DESCRIPTION
Several of our named states put joint 3 at PI. 

Looking through Joe's error log I believe that is the problem here 
`[ros2_control_node-1] [WARN] [1631376228.259487802] [KortexMultiInterfaceHardware]: Arms joint[2] command error is too large, setting command to current robot position. Error: 6.283488. Command: 3.142069, Actual: -3.141419`

If memory serves, the Kinova reports the joint angles for its continuous joints in [0, 2pi), but we have to translate that to [-pi, pi). Figuring out how to handle when it moves from -pi to -(pi+small amount) when Kinova is wrapping that to (+pi-small amount) is difficult with controller switching so we have a workaround right now.

However, it does not handle this case where you are right on the precipice. I'm sure Marq can provide more details, but I think this may fix the issue in the log file.