### PR TITLE
Increase write() block time during mode switching

### DIFF
--- a/kortex2_bringup/config/gen3.srdf
+++ b/kortex2_bringup/config/gen3.srdf
@@ -41,7 +41,7 @@
   <group_state group="manipulator" name="home">
     <joint name="joint_1" value="0"/>
     <joint name="joint_2" value="0.26"/>
-    <joint name="joint_3" value="3.14"/>
+    <joint name="joint_3" value="3.0"/>
     <joint name="joint_4" value="-2.27"/>
     <joint name="joint_5" value="0"/>
     <joint name="joint_6" value="0.96"/>
@@ -50,7 +50,7 @@
   <group_state group="manipulator" name="weigh">
     <joint name="joint_1" value="0"/>
     <joint name="joint_2" value="0"/>
-    <joint name="joint_3" value="3.14"/>
+    <joint name="joint_3" value="3.0"/>
     <joint name="joint_4" value="-2.27"/>
     <joint name="joint_5" value="0"/>
     <joint name="joint_6" value="0.7"/>
@@ -59,7 +59,7 @@
   <group_state group="manipulator" name="retract">
     <joint name="joint_1" value="0"/>
     <joint name="joint_2" value="-0.35"/>
-    <joint name="joint_3" value="3.14"/>
+    <joint name="joint_3" value="3.0"/>
     <joint name="joint_4" value="-2.54"/>
     <joint name="joint_5" value="0"/>
     <joint name="joint_6" value="-0.87"/>
@@ -86,7 +86,7 @@
   <group_state group="manipulator" name="puzzle">
     <joint name="joint_1" value="0.0"/>
     <joint name="joint_2" value="0.567"/>
-    <joint name="joint_3" value="-3.1"/>
+    <joint name="joint_3" value="-3.0"/>
     <joint name="joint_4" value="-0.68"/>
     <joint name="joint_5" value="-0.059"/>
     <joint name="joint_6" value="-1.904"/>

--- a/kortex2_driver/include/kortex2_driver/hardware_interface.hpp
+++ b/kortex2_driver/include/kortex2_driver/hardware_interface.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -91,7 +92,7 @@ private:
   double gripper_position_;
 
   rclcpp::Time controller_switch_time_;
-  bool block_write = false;
+  std::atomic<bool> block_write = false;
   k_api::Base::ServoingMode arm_mode_;
 
   // Enum defining at which control level we are

--- a/kortex2_driver/src/hardware_interface.cpp
+++ b/kortex2_driver/src/hardware_interface.cpp
@@ -242,9 +242,10 @@ return_type KortexMultiInterfaceHardware::prepare_command_mode_switch(const std:
   }
 
   // If we are not starting any controllers we are done
-  if (new_modes.empty()) {
-      block_write = false;
-      return return_type::OK;
+  if (new_modes.empty())
+  {
+    block_write = false;
+    return return_type::OK;
   }
   // Set the new command modes
   for (std::size_t i = 0; i < new_modes.size(); i++)

--- a/kortex2_driver/src/hardware_interface.cpp
+++ b/kortex2_driver/src/hardware_interface.cpp
@@ -162,6 +162,10 @@ std::vector<hardware_interface::CommandInterface> KortexMultiInterfaceHardware::
 return_type KortexMultiInterfaceHardware::prepare_command_mode_switch(const std::vector<std::string>& start_interfaces,
                                                                       const std::vector<std::string>& stop_interfaces)
 {
+  // sleep to ensure all outgoing write commands have finished
+  block_write = true;
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
   // Prepare for new command modes
   std::vector<integration_lvl_t> new_modes = {};
   std::vector<std::size_t> new_mode_joint_index = {};
@@ -214,9 +218,9 @@ return_type KortexMultiInterfaceHardware::prepare_command_mode_switch(const std:
   if (arm_mode_ == k_api::Base::ServoingMode::SINGLE_LEVEL_SERVOING &&
       arm_joints_control_level_[6] == integration_lvl_t::UNDEFINED)
   {
-    block_write = true;
-    std::this_thread::sleep_for(
-        std::chrono::milliseconds(50));  // sleep to ensure all outgoing write commands have finished
+    // block_write = true;
+    // std::this_thread::sleep_for(
+    //     std::chrono::milliseconds(50));  // sleep to ensure all outgoing write commands have finished
     arm_mode_ = k_api::Base::ServoingMode::UNSPECIFIED_SERVOING_MODE;
     RCLCPP_INFO(LOGGER, "Switching to NO_SERVOING_MODE");
     auto command = k_api::Base::TwistCommand();
@@ -234,13 +238,14 @@ return_type KortexMultiInterfaceHardware::prepare_command_mode_switch(const std:
     twist->set_angular_z(0.0f);
     base_.SendTwistCommand(command);
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    block_write = false;
+    // block_write = false;
   }
 
   // If we are not starting any controllers we are done
-  if (new_modes.empty())
-    return return_type::OK;
-
+  if (new_modes.empty()) {
+      block_write = false;
+      return return_type::OK;
+  }
   // Set the new command modes
   for (std::size_t i = 0; i < new_modes.size(); i++)
   {
@@ -251,6 +256,7 @@ return_type KortexMultiInterfaceHardware::prepare_command_mode_switch(const std:
           LOGGER,
           "Attempting to start interface that is already claimed. Joint mode index: %ld, arm_joints_control_level_[%d]",
           new_mode_joint_index[i], arm_joints_control_level_[new_mode_joint_index[i]]);
+      block_write = false;
       return return_type::ERROR;
     }
     arm_joints_control_level_[new_mode_joint_index[i]] = new_modes[i];
@@ -264,9 +270,9 @@ return_type KortexMultiInterfaceHardware::prepare_command_mode_switch(const std:
       info_.joints[new_mode_joint_index.front()].name !=
           "finger_joint")  // TODO find a better way to identify gripper joint(s)
   {
-    block_write = true;
-    std::this_thread::sleep_for(
-        std::chrono::milliseconds(50));  // sleep to ensure all outgoing write commands have finished
+    // block_write = true;
+    // std::this_thread::sleep_for(
+    //     std::chrono::milliseconds(50));  // sleep to ensure all outgoing write commands have finished
     auto servoing_mode = k_api::Base::ServoingModeInformation();
     // Set the base in low-level servoing mode
     arm_mode_ = k_api::Base::ServoingMode::LOW_LEVEL_SERVOING;
@@ -282,15 +288,15 @@ return_type KortexMultiInterfaceHardware::prepare_command_mode_switch(const std:
     }
     RCLCPP_INFO(LOGGER, "Switching to LOW_LEVEL_SERVOING");
     controller_switch_time_ = rclcpp::Clock().now();
-    block_write = false;
+    // block_write = false;
   }
   else if (arm_joints_control_level_[6] == integration_lvl_t::POSITION &&
            info_.joints[new_mode_joint_index.front()].name !=
                "finger_joint")  // TODO find a better way to identify gripper joint(s)
   {
-    block_write = true;
-    std::this_thread::sleep_for(
-        std::chrono::milliseconds(50));  // sleep to ensure all outgoing write commands have finished
+    // block_write = true;
+    // std::this_thread::sleep_for(
+    //     std::chrono::milliseconds(50));  // sleep to ensure all outgoing write commands have finished
     auto servoing_mode = k_api::Base::ServoingModeInformation();
     // Set the base in low-level servoing mode
     arm_mode_ = k_api::Base::ServoingMode::SINGLE_LEVEL_SERVOING;
@@ -305,13 +311,14 @@ return_type KortexMultiInterfaceHardware::prepare_command_mode_switch(const std:
     }
     RCLCPP_INFO(LOGGER, "Switching to SINGLE_LEVEL_SERVOING");
     controller_switch_time_ = rclcpp::Clock().now();
-    block_write = false;
+    // block_write = false;
   }
   else
   {
     RCLCPP_INFO(LOGGER, "Arm controller is not changing modes. arm_mode: %u", arm_mode_);
   }
 
+  block_write = false;
   return return_type::OK;
 }
 


### PR DESCRIPTION
We think there may still be lingering commands from before controller mode switching was called, which then result in trying to servo after we have switched to a non servo mode, resulting in this error message

```
[ros2_control_node-1] [ERROR] [1631384286.114141171] [KortexMultiInterfaceHardware]: Kortex exception: Device error, Error sub type=WRONG_SERVOING_MODE => <srv: 3, fct: 1, msgType: 3>
[ros2_control_node-1] description: Wrong servoing mode, must be low level servoing mode
[ros2_control_node-1] [ERROR] [1631384286.114158213] [KortexMultiInterfaceHardware]: Error sub-code: WRONG_SERVOING_MODE
```
This attempts to fix this by
- Start blocking at start of prepare_command_mode_switch
- Increase blocking time from 50 to 200ms
- Use atomic for block_write
