### PR TITLE
Improved fault recovery and controller handling

### DIFF
--- a/kortex2_driver/src/hardware_interface.cpp
+++ b/kortex2_driver/src/hardware_interface.cpp
@@ -711,11 +711,11 @@ CallbackReturn KortexMultiInterfaceHardware::on_deactivate(
 
 return_type KortexMultiInterfaceHardware::read()
 {
-  if (first_pass_)
-  {
-    feedback_ = base_cyclic_.RefreshFeedback();
-    first_pass_ = false;
-  }
+  //  if (first_pass_)
+  //  {
+  feedback_ = base_cyclic_.RefreshFeedback();
+  //    first_pass_ = false;
+  //  }
 
   // get arm servoing mode
   arm_mode_ = base_.GetServoingMode().servoing_mode();
@@ -847,7 +847,7 @@ return_type KortexMultiInterfaceHardware::write()
 
   // read one step late because reading before sending commands
   // generates errors
-  feedback_ = base_cyclic_.RefreshFeedback();
+  //  feedback_ = base_cyclic_.RefreshFeedback();
   return return_type::OK;
 }
 

--- a/kortex2_driver/src/hardware_interface.cpp
+++ b/kortex2_driver/src/hardware_interface.cpp
@@ -718,7 +718,7 @@ return_type KortexMultiInterfaceHardware::read()
   //  }
 
   // get arm servoing mode
-  arm_mode_ = base_.GetServoingMode().servoing_mode();
+  //  arm_mode_ = base_.GetServoingMode().servoing_mode();
 
   // read if robot is faulted
   in_fault_ = (feedback_.base().active_state() == Kinova::Api::Common::ArmState::ARMSTATE_IN_FAULT);

--- a/kortex2_driver/src/hardware_interface.cpp
+++ b/kortex2_driver/src/hardware_interface.cpp
@@ -711,11 +711,11 @@ CallbackReturn KortexMultiInterfaceHardware::on_deactivate(
 
 return_type KortexMultiInterfaceHardware::read()
 {
-  //  if (first_pass_)
-  //  {
+  if (first_pass_)
+  {
+    first_pass_ = false;
+  }
   feedback_ = base_cyclic_.RefreshFeedback();
-  //    first_pass_ = false;
-  //  }
 
   // get arm servoing mode
   //  arm_mode_ = base_.GetServoingMode().servoing_mode();
@@ -766,14 +766,6 @@ return_type KortexMultiInterfaceHardware::write()
     try
     {
       //      RCLCPP_INFO(LOGGER, "Fault controller check try...");
-      // remember controllers
-      //      twist_controller_running_tmp_ = twist_controller_running_;
-      //      joint_based_controller_running_tmp_ = twist_controller_running_;
-      //      gripper_controller_running_tmp_ = gripper_controller_running_;
-      // turn off controllers
-      //      twist_controller_running_ = false;
-      //      joint_based_controller_running_ = false;
-      //      gripper_controller_running_ = false;
       // change servoing mode first
       servoing_mode_hw_.set_servoing_mode(k_api::Base::ServoingMode::SINGLE_LEVEL_SERVOING);
       base_.SetServoingMode(servoing_mode_hw_);
@@ -787,11 +779,6 @@ return_type KortexMultiInterfaceHardware::write()
         servoing_mode_hw_.set_servoing_mode(arm_mode_);
         base_.SetServoingMode(servoing_mode_hw_);
       }
-      // turn on controllers
-      //      twist_controller_running_ = twist_controller_running_tmp_;
-      //      joint_based_controller_running_ = joint_based_controller_running_tmp_;
-      //      gripper_controller_running_ = gripper_controller_running_tmp_;
-
       reset_fault_async_success_ = 1.0;
     }
     catch (k_api::KDetailedException & ex)
@@ -844,10 +831,6 @@ return_type KortexMultiInterfaceHardware::write()
       RCLCPP_DEBUG(LOGGER, "No controller active!");
     }
   }
-
-  // read one step late because reading before sending commands
-  // generates errors
-  //  feedback_ = base_cyclic_.RefreshFeedback();
   return return_type::OK;
 }
 

--- a/kortex2_driver/src/hardware_interface.cpp
+++ b/kortex2_driver/src/hardware_interface.cpp
@@ -767,13 +767,13 @@ return_type KortexMultiInterfaceHardware::write()
     {
       //      RCLCPP_INFO(LOGGER, "Fault controller check try...");
       // remember controllers
-      twist_controller_running_tmp_ = twist_controller_running_;
-      joint_based_controller_running_tmp_ = twist_controller_running_;
-      gripper_controller_running_tmp_ = gripper_controller_running_;
+      //      twist_controller_running_tmp_ = twist_controller_running_;
+      //      joint_based_controller_running_tmp_ = twist_controller_running_;
+      //      gripper_controller_running_tmp_ = gripper_controller_running_;
       // turn off controllers
-      twist_controller_running_ = false;
-      joint_based_controller_running_ = false;
-      gripper_controller_running_ = false;
+      //      twist_controller_running_ = false;
+      //      joint_based_controller_running_ = false;
+      //      gripper_controller_running_ = false;
       // change servoing mode first
       servoing_mode_hw_.set_servoing_mode(k_api::Base::ServoingMode::SINGLE_LEVEL_SERVOING);
       base_.SetServoingMode(servoing_mode_hw_);
@@ -788,9 +788,9 @@ return_type KortexMultiInterfaceHardware::write()
         base_.SetServoingMode(servoing_mode_hw_);
       }
       // turn on controllers
-      twist_controller_running_ = twist_controller_running_tmp_;
-      joint_based_controller_running_ = joint_based_controller_running_tmp_;
-      gripper_controller_running_ = gripper_controller_running_tmp_;
+      //      twist_controller_running_ = twist_controller_running_tmp_;
+      //      joint_based_controller_running_ = joint_based_controller_running_tmp_;
+      //      gripper_controller_running_ = gripper_controller_running_tmp_;
 
       reset_fault_async_success_ = 1.0;
     }

--- a/ros2_kortex.repos
+++ b/ros2_kortex.repos
@@ -13,5 +13,5 @@ repositories:
     version: master
   ros2_controllers:
     type: git
-    url: https://github.com/destogl/ros2_controllers.git
-    version: multi-interface-ffw-ctrl
+    url: https://github.com/ros-controls/ros2_controllers.git
+    version: master


### PR DESCRIPTION
PR info:

- Don't send any commands when the robot is faulted except `ClearFaults()`
- Put reading before writing (after multiple changes no problem nor warnings appeared as described in the comments - e.g. reading before writing creates errors)
- No controller switching/turning on/off on fault recovery
- Keep the `arm_mode` as decided in controller switching mechanism ==> don't read it
- Change `ros2_controllers` version and url