### PR TITLE
No need for rclpy in cmake

### DIFF
--- a/kortex2_bringup/CMakeLists.txt
+++ b/kortex2_bringup/CMakeLists.txt
@@ -3,7 +3,6 @@ project(kortex2_bringup)
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
-find_package(rclpy REQUIRED)
 
 # Install Python executables
 install(PROGRAMS


### PR DESCRIPTION
This cherry-picks the original change from PR #81 the rest of the changes in that PR were applied in PR #84

This closes #81 