### PR TITLE
fixup branch for rolling

### DIFF
--- a/simulation.repos
+++ b/simulation.repos
@@ -8,7 +8,8 @@ repositories:
   ign_ros2_control:
     type: git
     url: https://github.com/ignitionrobotics/ign_ros2_control.git
-    version: main
+    version: master
+
   ros_ign:
     type: git
     url: https://github.com/ignitionrobotics/ros_ign.git


### PR DESCRIPTION
If the branch is wrong it seems to just clone the repo and take the default branch, so this wasn't failing it just printed a console warning we had been ignoring.