### PR TITLE
Add import-token to action-ros-ci and trigger on main

### DIFF
--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   pre-commit:

--- a/.github/workflows/humble-binary-build.yml
+++ b/.github/workflows/humble-binary-build.yml
@@ -2,10 +2,13 @@ name: Humble Binary Build
 on:
   pull_request:
     branches:
-      - master
+      # try to keep humble and rolling(main) in sync
+      - humble
+      - main
   push:
     branches:
-      - master
+      - humble
+      - main
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '13 4 * * *'

--- a/.github/workflows/humble-source-build.yml
+++ b/.github/workflows/humble-source-build.yml
@@ -2,7 +2,9 @@ name: Humble Source Build
 on:
   push:
     branches:
-      - master
+      # try to keep humble and rolling(main) in sync
+      - humble
+      - main
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '43 1 * * *'

--- a/.github/workflows/humble-source-build.yml
+++ b/.github/workflows/humble-source-build.yml
@@ -28,10 +28,9 @@ jobs:
           package-name:
             kortex2_bringup
             kortex2_driver
-          import-token: ${{ secrets.REPO_TOKEN }}
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
-            https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_kortex.repos?token=${{ secrets.REPO_TOKEN }}
+            file://${{ github.workspace }}/ros2_kortex.repos
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/humble-source-build.yml
+++ b/.github/workflows/humble-source-build.yml
@@ -26,7 +26,7 @@ jobs:
           package-name:
             kortex2_bringup
             kortex2_driver
-
+          import-token: ${{ secrets.GITHUB_TOKEN }}
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
             https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_kortex.repos?token=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/humble-source-build.yml
+++ b/.github/workflows/humble-source-build.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: ros-tooling/action-ros-ci@v0.3
         with:
           target-ros2-distro: ${{ env.ROS_DISTRO }}
+          import-token: ${{ secrets.GITHUB_TOKEN }}
           # build all packages listed in the meta package
           package-name:
             kortex2_bringup

--- a/.github/workflows/humble-source-build.yml
+++ b/.github/workflows/humble-source-build.yml
@@ -28,10 +28,10 @@ jobs:
           package-name:
             kortex2_bringup
             kortex2_driver
-          import-token: ${{ secrets.GITHUB_TOKEN }}
+          import-token: ${{ secrets.REPO_TOKEN }}
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
-            https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_kortex.repos?token=${{ secrets.GITHUB_TOKEN }}
+            https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_kortex.repos?token=${{ secrets.REPO_TOKEN }}
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/rolling-binary-build.yml
+++ b/.github/workflows/rolling-binary-build.yml
@@ -2,10 +2,10 @@ name: Rolling Binary Build
 on:
   pull_request:
     branches:
-      - master
+      - main
   push:
     branches:
-      - master
+      - main
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '13 4 * * *'

--- a/.github/workflows/rolling-semi-binary-build.yml
+++ b/.github/workflows/rolling-semi-binary-build.yml
@@ -2,10 +2,10 @@ name: Rolling Semi Binary Build
 on:
   pull_request:
     branches:
-      - master
+      - main
   push:
     branches:
-      - master
+      - main
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '13 4 * * *'

--- a/.github/workflows/rolling-source-build.yml
+++ b/.github/workflows/rolling-source-build.yml
@@ -29,10 +29,9 @@ jobs:
           package-name:
             kortex2_bringup
             kortex2_driver
-          import-token: ${{ secrets.REPO_TOKEN }}
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
-            https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_kortex.repos?token=${{ secrets.REPO_TOKEN }}
+            file://${{ github.workspace }}/ros2_kortex.repos
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/rolling-source-build.yml
+++ b/.github/workflows/rolling-source-build.yml
@@ -2,7 +2,7 @@ name: Rolling Source Build
 on:
   push:
     branches:
-      - master
+      - main
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '43 1 * * *'

--- a/.github/workflows/rolling-source-build.yml
+++ b/.github/workflows/rolling-source-build.yml
@@ -1,5 +1,8 @@
 name: Rolling Source Build
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main

--- a/.github/workflows/rolling-source-build.yml
+++ b/.github/workflows/rolling-source-build.yml
@@ -26,7 +26,7 @@ jobs:
           package-name:
             kortex2_bringup
             kortex2_driver
-
+          import-token: ${{ secrets.GITHUB_TOKEN }}
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
             https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_kortex.repos?token=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rolling-source-build.yml
+++ b/.github/workflows/rolling-source-build.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: ros-tooling/action-ros-ci@v0.3
         with:
           target-ros2-distro: ${{ env.ROS_DISTRO }}
+          import-token: ${{ secrets.GITHUB_TOKEN }}
           # build all packages listed in the meta package
           package-name:
             kortex2_bringup

--- a/.github/workflows/rolling-source-build.yml
+++ b/.github/workflows/rolling-source-build.yml
@@ -29,10 +29,10 @@ jobs:
           package-name:
             kortex2_bringup
             kortex2_driver
-          import-token: ${{ secrets.GITHUB_TOKEN }}
+          import-token: ${{ secrets.REPO_TOKEN }}
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
-            https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_kortex.repos?token=${{ secrets.GITHUB_TOKEN }}
+            https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_kortex.repos?token=${{ secrets.REPO_TOKEN }}
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
This is hard to test locally.
Found this related issue: https://github.com/ros-tooling/action-ros-ci/issues/691

Also noticed jobs were not getting triggered because of the branch name change. Updated CI in this PR