### PR TITLE
[CI] source build on main not on PRs

### DIFF
--- a/.github/workflows/rolling-source-build.yml
+++ b/.github/workflows/rolling-source-build.yml
@@ -1,8 +1,5 @@
 name: Rolling Source Build
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main


### PR DESCRIPTION
- Full source build is extremely slow (~2hr)
- Binary and Semi Binary give us enough coverage on PRs
- Source Build is still triggered on main periodically and post merge