### PR TITLE
[CI] enable rolling from upstream testing debs

### DIFF
--- a/.github/workflows/rolling-binary-build.yml
+++ b/.github/workflows/rolling-binary-build.yml
@@ -18,8 +18,7 @@ jobs:
       matrix:
         env:
           - {ROS_DISTRO: rolling, ROS_REPO: main}
-          #TODO(moriarty): re-enable rolling testing after rolling feature freeze, known failure upstream
-          #- {ROS_DISTRO: rolling, ROS_REPO: testing}
+          - {ROS_DISTRO: rolling, ROS_REPO: testing}
     env:
       UPSTREAM_WORKSPACE: ros2_kortex-not-released.${{ matrix.env.ROS_DISTRO }}.repos
       CCACHE_DIR: ${{ github.workspace }}/.ccache


### PR DESCRIPTION
Some more breakages are already in the rolling distro turning these on too to stay ahead of things