### PR TITLE
[kortex_api] use CMake FetchContent to get API

### DIFF
--- a/kortex_api/CMakeLists.txt
+++ b/kortex_api/CMakeLists.txt
@@ -1,17 +1,49 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.14)
+include(FetchContent)
+#include(ExternalProject)
+FetchContent_Declare(
+  kinova_binary_api
+  URL https://artifactory.kinovaapps.com:443/artifactory/generic-public/kortex/API/2.5.0/linux_x86-64_x86_gcc.zip
+  URL_HASH MD5=64bd86e7ab8bda90ef1fc7d6a356e080
+)
+
+FetchContent_MakeAvailable(kinova_binary_api)
+
 project(kortex_api)
+
+#Future:
+# convert API_URL components from CMAKE_SYSTEM variables.
+# The kinova artifactory server artifacts have slightly different expectations and they need some transformations
+# Could build something like: (URL_OS)_(URL_PROCESSOR)_(?)_(URL_COMPILER).zip
+# string(REPLACE "_" "-" URL_PROCESSOR ${CMAKE_SYSTEM_PROCESSOR}) # x86_64 -> x86-64
+# string(TOLOWER ${CMAKE_SYSTEM_NAME} URL_OS) # Linux -> linux
+
+#Current: only support Linux x86_64
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  set(API_URL https://artifactory.kinovaapps.com:443/artifactory/generic-public/kortex/API/2.5.0/linux_x86-64_x86_gcc.zip)
+else()
+  set(API_URL "")
+  message(FATAL_ERROR "Unsupported System: currently support is for Linux x68_64. Detected ${CMAKE_SYSTEM_NAME} and ${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+
+#ExternalProject_Add(kinova_binary_api
+#  URL ${API_URL}
+#  CONFIGURE_COMMAND ""
+#  BUILD_COMMAND ""
+#  INSTALL_COMMAND ""
+#)
 
 find_package(ament_cmake REQUIRED)
 
-ament_export_libraries(${CMAKE_CURRENT_SOURCE_DIR}/lib/release/libKortexApiCpp.a)
+ament_export_libraries(${kinova_binary_api_SOURCE_DIR}/lib/release/libKortexApiCpp.a)
 link_libraries(pthread)
 
-ament_export_include_directories(include)
+ament_export_include_directories(${kinova_binary_api_SOURCE_DIR}/include)
 
-install(DIRECTORY include/client/ DESTINATION include)
-install(DIRECTORY include/common/ DESTINATION include)
-install(DIRECTORY include/messages/ DESTINATION include)
-install(DIRECTORY include/client_stubs/ DESTINATION include)
-install(DIRECTORY include/google/protobuf DESTINATION include/google)
+install(DIRECTORY ${kinova_binary_api_SOURCE_DIR}/include/client/ DESTINATION include)
+install(DIRECTORY ${kinova_binary_api_SOURCE_DIR}/include/common/ DESTINATION include)
+install(DIRECTORY ${kinova_binary_api_SOURCE_DIR}/include/messages/ DESTINATION include)
+install(DIRECTORY ${kinova_binary_api_SOURCE_DIR}/include/client_stubs/ DESTINATION include)
+install(DIRECTORY ${kinova_binary_api_SOURCE_DIR}/include/google/protobuf DESTINATION include/google)
 
 ament_package()

--- a/kortex_api/CMakeLists.txt
+++ b/kortex_api/CMakeLists.txt
@@ -38,7 +38,7 @@ find_package(ament_cmake REQUIRED)
 ament_export_libraries(${kinova_binary_api_SOURCE_DIR}/lib/release/libKortexApiCpp.a)
 link_libraries(pthread)
 
-ament_export_include_directories(${kinova_binary_api_SOURCE_DIR}/include)
+ament_export_include_directories(include)
 
 install(DIRECTORY ${kinova_binary_api_SOURCE_DIR}/include/client/ DESTINATION include)
 install(DIRECTORY ${kinova_binary_api_SOURCE_DIR}/include/common/ DESTINATION include)


### PR DESCRIPTION
- This uses CMake FetchContent to get the API.
- Currently only Linux x86_64 is supported
- Adds comment for future use of ExternalProject_Add regardind detecting and pulling other versions of the API