### PR TITLE
Fix Sim Launch

### DIFF
--- a/kortex2_bringup/launch/kortex_sim_control.launch.py
+++ b/kortex2_bringup/launch/kortex_sim_control.launch.py
@@ -240,6 +240,14 @@ def generate_launch_description():
         arguments=[robot_hand_controller, "-c", "/controller_manager"],
     )
 
+    # Bridge
+    bridge = Node(
+        package="ros_gz_bridge",
+        executable="parameter_bridge",
+        arguments=["/clock@rosgraph_msgs/msg/Clock[ignition.msgs.Clock"],
+        output="screen",
+    )
+
     # Gazebo nodes
     gzserver = ExecuteProcess(
         cmd=["gzserver", "-s", "libgazebo_ros_init.so", "-s", "libgazebo_ros_factory.so", ""],
@@ -272,7 +280,7 @@ def generate_launch_description():
     )
 
     ignition_spawn_entity = Node(
-        package="ros_ign_gazebo",
+        package="ros_gz_sim",
         executable="create",
         output="screen",
         arguments=[
@@ -282,19 +290,32 @@ def generate_launch_description():
             robot_name,
             "-allow_renaming",
             "true",
+            "-x",
+            "0.0",
+            "-y",
+            "0.0",
+            "-z",
+            "0.3",
+            "-R",
+            "0.0",
+            "-P",
+            "0.0",
+            "-Y",
+            "0.0",
         ],
         condition=IfCondition(sim_ignition),
     )
 
     ignition_launch_description = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            [FindPackageShare("ros_ign_gazebo"), "/launch/ign_gazebo.launch.py"]
+            [FindPackageShare("ros_gz_sim"), "/launch/gz_sim.launch.py"]
         ),
         launch_arguments={"ign_args": " -r -v 3 empty.sdf"}.items(),
         condition=IfCondition(sim_ignition),
     )
 
     nodes_to_start = [
+        bridge,
         robot_state_publisher_node,
         joint_state_broadcaster_spawner,
         delay_rviz_after_joint_state_broadcaster_spawner,


### PR DESCRIPTION
- Added /clock seen upstream to fix humble issues
  - https://github.com/ros-controls/gz_ros2_control/issues/106
  - https://github.com/ros-controls/gz_ros2_control/pull/137
  - https://github.com/MarqRazz/c3pzero/pull/2
- [ros_ign_gazebo] is deprecated! Redirecting to use [ros_gz_sim] instead!
  - After this deprication warning a sh Syntax error was occuring which was hard to spot