### PR TITLE
CI: ROSDEP_SKIP_KEYS robotiq_description

### DIFF
--- a/.github/workflows/rolling-semi-binary-build.yml
+++ b/.github/workflows/rolling-semi-binary-build.yml
@@ -22,6 +22,7 @@ jobs:
           #- {ROS_DISTRO: rolling, ROS_REPO: testing}
     env:
       UPSTREAM_WORKSPACE: ros2_kortex.${{ matrix.env.ROS_DISTRO }}.repos
+      ROSDEP_SKIP_KEYS: robotiq_description
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       BASEDIR: ${{ github.workspace }}/.work
       CACHE_PREFIX: ${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}


### PR DESCRIPTION
rosdep --ignore-src seems to not work, this package is in the upstream workspace

- This package is not yet released.
- https://github.com/ros-industrial/industrial_ci/blob/master/doc/index.rst#optional-environment-variables