### PR TITLE
add parameter to use sim time to move_group launch

### DIFF
--- a/kortex2_bringup/launch/kortex_sim_control.launch.py
+++ b/kortex2_bringup/launch/kortex_sim_control.launch.py
@@ -51,6 +51,7 @@ def launch_setup(context, *args, **kwargs):
     robot_pos_controller = LaunchConfiguration("robot_pos_controller")
     robot_hand_controller = LaunchConfiguration("robot_hand_controller")
     launch_rviz = LaunchConfiguration("launch_rviz")
+    use_sim_time = LaunchConfiguration("use_sim_time")
 
     robot_controllers = PathJoinSubstitution(
         # https://answers.ros.org/question/397123/how-to-access-the-runtime-value-of-a-launchconfiguration-instance-within-custom-launch-code-injected-via-an-opaquefunction-in-ros2/
@@ -96,15 +97,21 @@ def launch_setup(context, *args, **kwargs):
             "simulation_controllers:=",
             robot_controllers,
             " ",
+            "gripper:=",
+            "robotiq_2f_85",
+            " ",
         ]
     )
-    robot_description = {"robot_description": robot_description_content}
+    robot_description = {"robot_description": robot_description_content.perform(context)}
 
     robot_state_publisher_node = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="both",
-        parameters=[robot_description],
+        parameters=[
+            robot_description,
+            {"use_sim_time": use_sim_time},
+        ],
     )
 
     rviz_node = Node(
@@ -336,6 +343,13 @@ def generate_launch_description():
             "robot_hand_controller",
             default_value="robotiq_gripper_controller",
             description="Robot hand controller to start.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_sim_time",
+            default_value="True",
+            description="Use simulated clock",
         )
     )
     declared_arguments.append(

--- a/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/config/ompl_planning.yaml
+++ b/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/config/ompl_planning.yaml
@@ -1,0 +1,10 @@
+planning_plugin: ompl_interface/OMPLPlanner
+start_state_max_bounds_error: 0.1
+jiggle_fraction: 0.05
+request_adapters: >-
+    default_planner_request_adapters/AddTimeOptimalParameterization
+    default_planner_request_adapters/ResolveConstraintFrames
+    default_planner_request_adapters/FixWorkspaceBounds
+    default_planner_request_adapters/FixStartStateBounds
+    default_planner_request_adapters/FixStartStateCollision
+    default_planner_request_adapters/FixStartStatePathConstraints

--- a/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/move_group.launch.py
+++ b/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/move_group.launch.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from launch.substitutions import LaunchConfiguration
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.actions import DeclareLaunchArgument
 from moveit_configs_utils import MoveItConfigsBuilder
 from moveit_configs_utils.launches import generate_move_group_launch
 

--- a/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/move_group.launch.py
+++ b/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/move_group.launch.py
@@ -17,6 +17,7 @@ from launch.actions import DeclareLaunchArgument
 from moveit_configs_utils import MoveItConfigsBuilder
 from moveit_configs_utils.launches import generate_move_group_launch
 
+
 def generate_launch_description():
     # Declare arguments
     declared_arguments = []
@@ -58,6 +59,6 @@ def generate_launch_description():
         .to_moveit_configs()
     )
 
-    moveit_config.moveit_cpp.update({"use_sim_time": LaunchConfiguration("use_sim_time") })
+    moveit_config.moveit_cpp.update({"use_sim_time": LaunchConfiguration("use_sim_time")})
 
     return generate_move_group_launch(moveit_config)

--- a/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/move_group.launch.py
+++ b/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/move_group.launch.py
@@ -12,13 +12,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+from launch.substitutions import LaunchConfiguration
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from moveit_configs_utils import MoveItConfigsBuilder
 from moveit_configs_utils.launches import generate_move_group_launch
 
-
 def generate_launch_description():
-    moveit_config = MoveItConfigsBuilder(
-        "gen3", package_name="kinova_gen3_6dof_robotiq_2f_85_moveit_config"
-    ).to_moveit_configs()
+    # Declare arguments
+    declared_arguments = []
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "robot_ip",
+            description="IP address by which the robot can be reached.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_fake_hardware",
+            default_value="false",
+            description="Start robot with fake hardware mirroring command to its states.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_sim_time",
+            default_value="false",
+            description="Use simulated clock",
+        )
+    )
+
+    # Initialize Arguments
+    robot_ip = LaunchConfiguration("robot_ip")
+    use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+
+    launch_arguments = {
+        "robot_ip": robot_ip,
+        "use_fake_hardware": use_fake_hardware,
+        "gripper": "robotiq_2f_85",
+        "dof": "6",
+    }
+
+    moveit_config = (
+        MoveItConfigsBuilder("gen3", package_name="kinova_gen3_6dof_robotiq_2f_85_moveit_config")
+        .robot_description(mappings=launch_arguments)
+        .to_moveit_configs()
+    )
+
+    moveit_config.moveit_cpp.update({"use_sim_time": LaunchConfiguration("use_sim_time") })
+
     return generate_move_group_launch(moveit_config)

--- a/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
+++ b/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
@@ -35,6 +35,13 @@ def generate_launch_description():
             description="Start robot with fake hardware mirroring command to its states.",
         )
     )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_sim_time",
+            default_value="false",
+            description="Use simulated clock",
+        )
+    )
 
     # Initialize Arguments
     robot_ip = LaunchConfiguration("robot_ip")
@@ -52,4 +59,6 @@ def generate_launch_description():
         .robot_description(mappings=launch_arguments)
         .to_moveit_configs()
     )
+
+    moveit_config.moveit_cpp.update({"use_sim_time": LaunchConfiguration("use_sim_time") })
     return generate_demo_launch(moveit_config)

--- a/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
+++ b/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
@@ -60,5 +60,5 @@ def generate_launch_description():
         .to_moveit_configs()
     )
 
-    moveit_config.moveit_cpp.update({"use_sim_time": LaunchConfiguration("use_sim_time") })
+    moveit_config.moveit_cpp.update({"use_sim_time": LaunchConfiguration("use_sim_time")})
     return generate_demo_launch(moveit_config)

--- a/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
+++ b/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
@@ -110,7 +110,7 @@ def generate_launch_description():
 
     description_arguments = {
         "robot_name" : robot_name,
-        "prefix" : prefix
+        "prefix" : prefix,
         "robot_ip": "xxx.yyy.zzz.www",
         "use_fake_hardware": "false",
         "gripper": "robotiq_2f_85",

--- a/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
+++ b/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
@@ -103,19 +103,18 @@ def generate_launch_description():
     )
 
     # Initialize Arguments
-
-    # sim_ignition = LaunchConfiguration("sim_ignition")
-    moveit_config_package = LaunchConfiguration("moveit_config_package")
-    # robot_name = LaunchConfiguration("robot_name")
-    # prefix = LaunchConfiguration("prefix")
+    robot_name = LaunchConfiguration("robot_name")
+    prefix = LaunchConfiguration("prefix")
     launch_rviz = LaunchConfiguration("launch_rviz")
     use_sim_time = LaunchConfiguration("use_sim_time")
 
     description_arguments = {
+        "robot_name" : robot_name,
+        "prefix" : prefix
         "robot_ip": "xxx.yyy.zzz.www",
         "use_fake_hardware": "false",
         "gripper": "robotiq_2f_85",
-        "dof": "6",
+        "dof": "7",
         "sim_ignition": "True",
     }
 

--- a/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
+++ b/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
@@ -109,8 +109,8 @@ def generate_launch_description():
     use_sim_time = LaunchConfiguration("use_sim_time")
 
     description_arguments = {
-        "robot_name" : robot_name,
-        "prefix" : prefix,
+        "robot_name": robot_name,
+        "prefix": prefix,
         "robot_ip": "xxx.yyy.zzz.www",
         "use_fake_hardware": "false",
         "gripper": "robotiq_2f_85",

--- a/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
+++ b/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
@@ -37,60 +37,6 @@ def generate_launch_description():
             description="Use Ignition for simulation",
         )
     )
-    # General arguments
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "controllers_file",
-            default_value="ros2_controllers.yaml",
-            description="YAML file with the controllers configuration.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "description_package",
-            default_value="kortex_description",
-            description="Description package with robot URDF/XACRO files. Usually the argument \
-        is not set, it enables use of a custom description.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "description_file",
-            default_value="kinova.urdf.xacro",
-            description="URDF/XACRO description file with the robot.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "moveit_config_package",
-            default_value="kinova_gen3_6dof_robotiq_2f_85_moveit_config",
-            description="MoveIt configuration package for the robot. Usually the argument \
-        is not set, it enables use of a custom config package.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "moveit_config_file",
-            default_value="gen3.srdf",
-            description="MoveIt SRDF/XACRO description file with the robot.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "robot_name",
-            default_value="gen3",
-            description="Robot name.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "prefix",
-            default_value='""',
-            description="Prefix of the joint names, useful for \
-        multi-robot setup. If changed than also joint names in the controllers' configuration \
-        have to be updated.",
-        )
-    )
     declared_arguments.append(
         DeclareLaunchArgument(
             "use_sim_time",
@@ -103,19 +49,16 @@ def generate_launch_description():
     )
 
     # Initialize Arguments
-    robot_name = LaunchConfiguration("robot_name")
-    prefix = LaunchConfiguration("prefix")
     launch_rviz = LaunchConfiguration("launch_rviz")
     use_sim_time = LaunchConfiguration("use_sim_time")
+    sim_ignition = LaunchConfiguration("sim_ignition")
 
     description_arguments = {
-        "robot_name": robot_name,
-        "prefix": prefix,
         "robot_ip": "xxx.yyy.zzz.www",
         "use_fake_hardware": "false",
         "gripper": "robotiq_2f_85",
         "dof": "7",
-        "sim_ignition": "True",
+        "sim_ignition": sim_ignition,
     }
 
     moveit_config = (

--- a/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
+++ b/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2023 PickNik, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Anthony Baker
+
+import os
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch.conditions import IfCondition
+
+from ament_index_python.packages import get_package_share_directory
+
+from moveit_configs_utils import MoveItConfigsBuilder
+
+
+def generate_launch_description():
+    declared_arguments = []
+    # Simulation specific arguments
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "sim_ignition",
+            default_value="true",
+            description="Use Ignition for simulation",
+        )
+    )
+    # General arguments
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "controllers_file",
+            default_value="ros2_controllers.yaml",
+            description="YAML file with the controllers configuration.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "description_package",
+            default_value="kortex_description",
+            description="Description package with robot URDF/XACRO files. Usually the argument \
+        is not set, it enables use of a custom description.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "description_file",
+            default_value="kinova.urdf.xacro",
+            description="URDF/XACRO description file with the robot.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "moveit_config_package",
+            default_value="kinova_gen3_6dof_robotiq_2f_85_moveit_config",
+            description="MoveIt configuration package for the robot. Usually the argument \
+        is not set, it enables use of a custom config package.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "moveit_config_file",
+            default_value="gen3.srdf",
+            description="MoveIt SRDF/XACRO description file with the robot.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "robot_name",
+            default_value="gen3",
+            description="Robot name.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "prefix",
+            default_value='""',
+            description="Prefix of the joint names, useful for \
+        multi-robot setup. If changed than also joint names in the controllers' configuration \
+        have to be updated.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_sim_time",
+            default_value="False",
+            description="Use simulated clock",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument("launch_rviz", default_value="true", description="Launch RViz?")
+    )
+
+    # Initialize Arguments
+
+    # sim_ignition = LaunchConfiguration("sim_ignition")
+    moveit_config_package = LaunchConfiguration("moveit_config_package")
+    # robot_name = LaunchConfiguration("robot_name")
+    # prefix = LaunchConfiguration("prefix")
+    launch_rviz = LaunchConfiguration("launch_rviz")
+    use_sim_time = LaunchConfiguration("use_sim_time")
+
+    description_arguments = {
+        "robot_ip": "xxx.yyy.zzz.www",
+        "use_fake_hardware": "false",
+        "gripper": "robotiq_2f_85",
+        "dof": "6",
+        "sim_ignition": "True",
+    }
+
+    moveit_config = (
+        MoveItConfigsBuilder("gen3", package_name="kinova_gen3_6dof_robotiq_2f_85_moveit_config")
+        .robot_description(mappings=description_arguments)
+        .planning_scene_monitor(publish_robot_description=True)
+        .to_moveit_configs()
+    )
+
+    # Start the actual move_group node/action server
+    move_group_node = Node(
+        package="moveit_ros_move_group",
+        executable="move_group",
+        output="log",
+        parameters=[moveit_config.to_dict(), {"use_sim_time": use_sim_time}],
+        arguments=[
+            "--ros-args",
+            "--log-level",
+            "fatal",
+        ],  # MoveIt is spamming the log because of unknown '*_mimic' joints
+        condition=IfCondition(launch_rviz),
+    )
+
+    rviz_config_path = os.path.join(
+        get_package_share_directory("kinova_gen3_6dof_robotiq_2f_85_moveit_config"),
+        "config",
+        "moveit.rviz",
+    )
+
+    rviz_node = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        output="log",
+        arguments=["-d", rviz_config_path],
+        parameters=[
+            moveit_config.robot_description,
+            moveit_config.robot_description_semantic,
+            moveit_config.planning_pipelines,
+            moveit_config.robot_description_kinematics,
+            moveit_config.joint_limits,
+            {"use_sim_time": use_sim_time},
+        ],
+        condition=IfCondition(launch_rviz),
+    )
+
+    return LaunchDescription(declared_arguments + [move_group_node, rviz_node])

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/config/ompl_planning.yaml
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/config/ompl_planning.yaml
@@ -1,0 +1,10 @@
+planning_plugin: ompl_interface/OMPLPlanner
+start_state_max_bounds_error: 0.1
+jiggle_fraction: 0.05
+request_adapters: >-
+    default_planner_request_adapters/AddTimeOptimalParameterization
+    default_planner_request_adapters/ResolveConstraintFrames
+    default_planner_request_adapters/FixWorkspaceBounds
+    default_planner_request_adapters/FixStartStateBounds
+    default_planner_request_adapters/FixStartStateCollision
+    default_planner_request_adapters/FixStartStatePathConstraints

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/move_group.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/move_group.launch.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from moveit_configs_utils import MoveItConfigsBuilder
 from moveit_configs_utils.launches import generate_move_group_launch
 

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/move_group.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/move_group.launch.py
@@ -58,5 +58,5 @@ def generate_launch_description():
         .to_moveit_configs()
     )
 
-    moveit_config.moveit_cpp.update({"use_sim_time": LaunchConfiguration("use_sim_time") })
+    moveit_config.moveit_cpp.update({"use_sim_time": LaunchConfiguration("use_sim_time")})
     return generate_move_group_launch(moveit_config)

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/move_group.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/move_group.launch.py
@@ -12,52 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
+
 from moveit_configs_utils import MoveItConfigsBuilder
 from moveit_configs_utils.launches import generate_move_group_launch
 
 
 def generate_launch_description():
-    # Declare arguments
-    declared_arguments = []
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "robot_ip",
-            description="IP address by which the robot can be reached.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "use_fake_hardware",
-            default_value="false",
-            description="Start robot with fake hardware mirroring command to its states.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "use_sim_time",
-            default_value="false",
-            description="Use simulated clock",
-        )
-    )
+    moveit_config = MoveItConfigsBuilder(
+        "gen3", package_name="kinova_gen3_7dof_robotiq_2f_85_moveit_config"
+    ).to_moveit_configs()
 
-    # Initialize Arguments
-    robot_ip = LaunchConfiguration("robot_ip")
-    use_fake_hardware = LaunchConfiguration("use_fake_hardware")
-
-    launch_arguments = {
-        "robot_ip": robot_ip,
-        "use_fake_hardware": use_fake_hardware,
-        "gripper": "robotiq_2f_85",
-        "dof": "7",
-    }
-
-    moveit_config = (
-        MoveItConfigsBuilder("gen3", package_name="kinova_gen3_6dof_robotiq_2f_85_moveit_config")
-        .robot_description(mappings=launch_arguments)
-        .to_moveit_configs()
-    )
-
-    moveit_config.moveit_cpp.update({"use_sim_time": LaunchConfiguration("use_sim_time")})
     return generate_move_group_launch(moveit_config)

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/move_group.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/move_group.launch.py
@@ -18,7 +18,45 @@ from moveit_configs_utils.launches import generate_move_group_launch
 
 
 def generate_launch_description():
-    moveit_config = MoveItConfigsBuilder(
-        "gen3", package_name="kinova_gen3_7dof_robotiq_2f_85_moveit_config"
-    ).to_moveit_configs()
+    # Declare arguments
+    declared_arguments = []
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "robot_ip",
+            description="IP address by which the robot can be reached.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_fake_hardware",
+            default_value="false",
+            description="Start robot with fake hardware mirroring command to its states.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_sim_time",
+            default_value="false",
+            description="Use simulated clock",
+        )
+    )
+
+    # Initialize Arguments
+    robot_ip = LaunchConfiguration("robot_ip")
+    use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+
+    launch_arguments = {
+        "robot_ip": robot_ip,
+        "use_fake_hardware": use_fake_hardware,
+        "gripper": "robotiq_2f_85",
+        "dof": "7",
+    }
+
+    moveit_config = (
+        MoveItConfigsBuilder("gen3", package_name="kinova_gen3_6dof_robotiq_2f_85_moveit_config")
+        .robot_description(mappings=launch_arguments)
+        .to_moveit_configs()
+    )
+
+    moveit_config.moveit_cpp.update({"use_sim_time": LaunchConfiguration("use_sim_time") })
     return generate_move_group_launch(moveit_config)

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
@@ -60,5 +60,5 @@ def generate_launch_description():
         .to_moveit_configs()
     )
 
-    moveit_config.moveit_cpp.update({"use_sim_time": LaunchConfiguration("use_sim_time") })
+    moveit_config.moveit_cpp.update({"use_sim_time": LaunchConfiguration("use_sim_time")})
     return generate_demo_launch(moveit_config)

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
@@ -35,6 +35,13 @@ def generate_launch_description():
             description="Start robot with fake hardware mirroring command to its states.",
         )
     )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_sim_time",
+            default_value="false",
+            description="Use simulated clock",
+        )
+    )
 
     # Initialize Arguments
     robot_ip = LaunchConfiguration("robot_ip")
@@ -48,8 +55,10 @@ def generate_launch_description():
     }
 
     moveit_config = (
-        MoveItConfigsBuilder("gen3", package_name="kinova_gen3_7dof_robotiq_2f_85_moveit_config")
+        MoveItConfigsBuilder("gen3", package_name="kinova_gen3_6dof_robotiq_2f_85_moveit_config")
         .robot_description(mappings=launch_arguments)
         .to_moveit_configs()
     )
+
+    moveit_config.moveit_cpp.update({"use_sim_time": LaunchConfiguration("use_sim_time") })
     return generate_demo_launch(moveit_config)

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
@@ -55,7 +55,7 @@ def generate_launch_description():
     }
 
     moveit_config = (
-        MoveItConfigsBuilder("gen3", package_name="kinova_gen3_6dof_robotiq_2f_85_moveit_config")
+        MoveItConfigsBuilder("gen3", package_name="kinova_gen3_7dof_robotiq_2f_85_moveit_config")
         .robot_description(mappings=launch_arguments)
         .to_moveit_configs()
     )

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
@@ -110,7 +110,7 @@ def generate_launch_description():
 
     description_arguments = {
         "robot_name" : robot_name,
-        "prefix" : prefix
+        "prefix" : prefix,
         "robot_ip": "xxx.yyy.zzz.www",
         "use_fake_hardware": "false",
         "gripper": "robotiq_2f_85",

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2023 PickNik, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Anthony Baker
+
+import os
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch.conditions import IfCondition
+
+from ament_index_python.packages import get_package_share_directory
+
+from moveit_configs_utils import MoveItConfigsBuilder
+
+
+def generate_launch_description():
+    declared_arguments = []
+    # Simulation specific arguments
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "sim_ignition",
+            default_value="true",
+            description="Use Ignition for simulation",
+        )
+    )
+    # General arguments
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "controllers_file",
+            default_value="ros2_controllers.yaml",
+            description="YAML file with the controllers configuration.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "description_package",
+            default_value="kortex_description",
+            description="Description package with robot URDF/XACRO files. Usually the argument \
+        is not set, it enables use of a custom description.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "description_file",
+            default_value="kinova.urdf.xacro",
+            description="URDF/XACRO description file with the robot.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "moveit_config_package",
+            default_value="kinova_gen3_7dof_robotiq_2f_85_moveit_config",
+            description="MoveIt configuration package for the robot. Usually the argument \
+        is not set, it enables use of a custom config package.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "moveit_config_file",
+            default_value="gen3.srdf",
+            description="MoveIt SRDF/XACRO description file with the robot.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "robot_name",
+            default_value="gen3",
+            description="Robot name.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "prefix",
+            default_value='""',
+            description="Prefix of the joint names, useful for \
+        multi-robot setup. If changed than also joint names in the controllers' configuration \
+        have to be updated.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_sim_time",
+            default_value="False",
+            description="Use simulated clock",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument("launch_rviz", default_value="true", description="Launch RViz?")
+    )
+
+    # Initialize Arguments
+
+    # sim_ignition = LaunchConfiguration("sim_ignition")
+    moveit_config_package = LaunchConfiguration("moveit_config_package")
+    # robot_name = LaunchConfiguration("robot_name")
+    # prefix = LaunchConfiguration("prefix")
+    launch_rviz = LaunchConfiguration("launch_rviz")
+    use_sim_time = LaunchConfiguration("use_sim_time")
+
+    description_arguments = {
+        "robot_ip": "xxx.yyy.zzz.www",
+        "use_fake_hardware": "false",
+        "gripper": "robotiq_2f_85",
+        "dof": "7",
+        "sim_ignition": "True",
+    }
+
+    moveit_config = (
+        MoveItConfigsBuilder("gen3", package_name="kinova_gen3_7dof_robotiq_2f_85_moveit_config")
+        .robot_description(mappings=description_arguments)
+        .planning_scene_monitor(publish_robot_description=True)
+        .to_moveit_configs()
+    )
+
+    # Start the actual move_group node/action server
+    move_group_node = Node(
+        package="moveit_ros_move_group",
+        executable="move_group",
+        output="log",
+        parameters=[moveit_config.to_dict(), {"use_sim_time": use_sim_time}],
+        arguments=[
+            "--ros-args",
+            "--log-level",
+            "fatal",
+        ],  # MoveIt is spamming the log because of unknown '*_mimic' joints
+        condition=IfCondition(launch_rviz),
+    )
+
+    rviz_config_path = os.path.join(
+        get_package_share_directory("kinova_gen3_7dof_robotiq_2f_85_moveit_config"),
+        "config",
+        "moveit.rviz",
+    )
+
+    rviz_node = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        output="log",
+        arguments=["-d", rviz_config_path],
+        parameters=[
+            moveit_config.robot_description,
+            moveit_config.robot_description_semantic,
+            moveit_config.planning_pipelines,
+            moveit_config.robot_description_kinematics,
+            moveit_config.joint_limits,
+            {"use_sim_time": use_sim_time},
+        ],
+        condition=IfCondition(launch_rviz),
+    )
+
+    return LaunchDescription(declared_arguments + [move_group_node, rviz_node])

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
@@ -37,60 +37,6 @@ def generate_launch_description():
             description="Use Ignition for simulation",
         )
     )
-    # General arguments
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "controllers_file",
-            default_value="ros2_controllers.yaml",
-            description="YAML file with the controllers configuration.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "description_package",
-            default_value="kortex_description",
-            description="Description package with robot URDF/XACRO files. Usually the argument \
-        is not set, it enables use of a custom description.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "description_file",
-            default_value="kinova.urdf.xacro",
-            description="URDF/XACRO description file with the robot.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "moveit_config_package",
-            default_value="kinova_gen3_7dof_robotiq_2f_85_moveit_config",
-            description="MoveIt configuration package for the robot. Usually the argument \
-        is not set, it enables use of a custom config package.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "moveit_config_file",
-            default_value="gen3.srdf",
-            description="MoveIt SRDF/XACRO description file with the robot.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "robot_name",
-            default_value="gen3",
-            description="Robot name.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "prefix",
-            default_value='""',
-            description="Prefix of the joint names, useful for \
-        multi-robot setup. If changed than also joint names in the controllers' configuration \
-        have to be updated.",
-        )
-    )
     declared_arguments.append(
         DeclareLaunchArgument(
             "use_sim_time",
@@ -103,19 +49,16 @@ def generate_launch_description():
     )
 
     # Initialize Arguments
-    robot_name = LaunchConfiguration("robot_name")
-    prefix = LaunchConfiguration("prefix")
     launch_rviz = LaunchConfiguration("launch_rviz")
     use_sim_time = LaunchConfiguration("use_sim_time")
+    sim_ignition = LaunchConfiguration("sim_ignition")
 
     description_arguments = {
-        "robot_name": robot_name,
-        "prefix": prefix,
         "robot_ip": "xxx.yyy.zzz.www",
         "use_fake_hardware": "false",
         "gripper": "robotiq_2f_85",
         "dof": "7",
-        "sim_ignition": "True",
+        "sim_ignition": sim_ignition,
     }
 
     moveit_config = (

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
@@ -109,8 +109,8 @@ def generate_launch_description():
     use_sim_time = LaunchConfiguration("use_sim_time")
 
     description_arguments = {
-        "robot_name" : robot_name,
-        "prefix" : prefix,
+        "robot_name": robot_name,
+        "prefix": prefix,
         "robot_ip": "xxx.yyy.zzz.www",
         "use_fake_hardware": "false",
         "gripper": "robotiq_2f_85",

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
@@ -103,15 +103,14 @@ def generate_launch_description():
     )
 
     # Initialize Arguments
-
-    # sim_ignition = LaunchConfiguration("sim_ignition")
-    moveit_config_package = LaunchConfiguration("moveit_config_package")
-    # robot_name = LaunchConfiguration("robot_name")
-    # prefix = LaunchConfiguration("prefix")
+    robot_name = LaunchConfiguration("robot_name")
+    prefix = LaunchConfiguration("prefix")
     launch_rviz = LaunchConfiguration("launch_rviz")
     use_sim_time = LaunchConfiguration("use_sim_time")
 
     description_arguments = {
+        "robot_name" : robot_name,
+        "prefix" : prefix
         "robot_ip": "xxx.yyy.zzz.www",
         "use_fake_hardware": "false",
         "gripper": "robotiq_2f_85",

--- a/readme.md
+++ b/readme.md
@@ -76,9 +76,13 @@ To simulate the 7 DoF Kinova Gen3 robot with gazebo run the following:
    ros2 launch kortex2_bringup kortex_sim_control.launch.py sim_gazebo:=true sim_ignition:=false
    ```
 
-To simulate the robot with ignition run the following:
+To simulate the 7dof Kinova Gen3 robot with ignition run the following:
    ```
-   ros2 launch kortex2_bringup kortex_sim_control.launch.py
+   ros2 launch kortex2_bringup kortex_sim_control.launch.py dof:=7 use_sim_time:=true launch_rviz:=false
+   ```
+and to use MoveIt to command the robot:
+   ```
+   ros2 launch kinova_gen3_7dof_robotiq_2f_85_moveit_config sim.launch.py
    ```
 
 To work with a physical robot and generate/execute paths with MoveIt run the following:

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ To simulate the 7dof Kinova Gen3 robot with ignition run the following:
    ```
 and to use MoveIt to command the robot:
    ```
-   ros2 launch kinova_gen3_7dof_robotiq_2f_85_moveit_config sim.launch.py
+   ros2 launch kinova_gen3_7dof_robotiq_2f_85_moveit_config sim.launch.py use_sim_time:=true
    ```
 
 To work with a physical robot and generate/execute paths with MoveIt run the following:


### PR DESCRIPTION
Adds a launch argument to get `use_sim_time` parameter so that we can use the moveit configs in sim.

Test:

1. Launch gazebo and RViz:`ros2 launch kortex2_bringup kortex_sim_control.launch.py dof:=7 use_sim_time:=true launch_rviz:=false` 
2. In a separate terminal, launch move group node with `use_sim_time` on: `ros2 launch kinova_gen3_7dof_robotiq_2f_85_moveit_config sim.launch.py`
3. In RViz, add the `motion planning` panel and use `plan and execute` using a valid goal.
