### PR TITLE
Add camera to 7dof gen3 ignition sim

### DIFF
--- a/kortex2_bringup/launch/kortex_sim_control.launch.py
+++ b/kortex2_bringup/launch/kortex_sim_control.launch.py
@@ -247,23 +247,7 @@ def launch_setup(context, *args, **kwargs):
             "/wrist_mounted_camera/depth_image@sensor_msgs/msg/Image[ignition.msgs.Image",
             "/wrist_mounted_camera/points@sensor_msgs/msg/PointCloud2[ignition.msgs.PointCloudPacked",
             "/wrist_mounted_camera/camera_info@sensor_msgs/msg/CameraInfo[ignition.msgs.CameraInfo",
-            # "/clock@rosgraph_msgs/msg/Clock[ignition.msgs.Clock",
         ],
-        # remappings=[
-        #     ("/wrist_mounted_camera/image", "/wrist_mounted_camera/color/image_raw"),
-        #     (
-        #         "/wrist_mounted_camera/camera_info",
-        #         "/wrist_mounted_camera/color/camera_info",
-        #     ),
-        #     (
-        #         "/wrist_mounted_camera/depth_image",
-        #         "/wrist_mounted_camera/depth/image_rect_raw",
-        #     ),
-        #     (
-        #         "/wrist_mounted_camera/points",
-        #         "/wrist_mounted_camera/depth/color/points",
-        #     ),
-        # ],
         output="screen",
     )
 

--- a/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
+++ b/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
@@ -296,7 +296,7 @@
           <mesh filename="file://$(find kortex_description)/arms/gen3/${dof}dof/meshes/bracelet_with_vision_link.STL" />
         </geometry>
         <material name="">
-          <color rgba="0.75294 0 0 1" />
+          <color rgba="0.75294 0.75294 0.75294 1" />
         </material>
       </visual>
       <collision>

--- a/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
+++ b/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
@@ -359,24 +359,47 @@
     </joint>
     <!-- TODO(destogl) this probably collides with camera URDF -->
     <xacro:if value="${vision}">
-      <link name="${prefix}camera_link" />
-      <joint name="${prefix}camera_module" type="fixed">
-        <origin xyz="0 0.05639 0.01305" rpy="0 -1.570796326794897 -1.570796326794897" />
-        <parent link="${prefix}end_effector_link" />
-        <child  link="${prefix}camera_link" />
-      </joint>
-      <link name="${prefix}camera_depth_frame" />
-      <joint name="${prefix}depth_module" type="fixed">
-        <origin xyz="0.0275 0.066 0.01305" rpy="0 -1.570796326794897 -1.570796326794897" />
-        <parent link="${prefix}end_effector_link" />
-        <child  link="${prefix}camera_depth_frame" />
-      </joint>
-      <link name="${prefix}camera_color_frame" />
-      <joint name="${prefix}color_module" type="fixed">
-        <origin xyz="0 0.05639 0.01305" rpy="0 -1.570796326794897 -1.570796326794897" />
-        <parent link="${prefix}end_effector_link" />
-        <child  link="${prefix}camera_color_frame" />
-      </joint>
+      <!-- sim camera needs to be rotated which might not apply to built in vision module -->
+      <xacro:if value="${sim_ignition}">
+        <link name="${prefix}camera_link" />
+        <joint name="${prefix}camera_module" type="fixed">
+          <origin xyz="0 0.05639 0.01305" rpy="0 -1.570796326794897 -1.570796326794897" />
+          <parent link="${prefix}end_effector_link" />
+          <child  link="${prefix}camera_link" />
+        </joint>
+        <link name="${prefix}camera_depth_frame" />
+        <joint name="${prefix}depth_module" type="fixed">
+          <origin xyz="0.0275 0.066 0.01305" rpy="0 -1.570796326794897 -1.570796326794897" />
+          <parent link="${prefix}end_effector_link" />
+          <child  link="${prefix}camera_depth_frame" />
+        </joint>
+        <link name="${prefix}camera_color_frame" />
+        <joint name="${prefix}color_module" type="fixed">
+          <origin xyz="0 0.05639 0.01305" rpy="0 -1.570796326794897 -1.570796326794897" />
+          <parent link="${prefix}end_effector_link" />
+          <child  link="${prefix}camera_color_frame" />
+        </joint>
+      </xacro:if>
+      <xacro:unless value="${sim_ignition}">
+        <link name="${prefix}camera_link" />
+        <joint name="${prefix}camera_module" type="fixed">
+          <origin xyz="0 0.05639 0.01305" rpy="0 -1.570796326794897 -1.570796326794897" />
+          <parent link="${prefix}end_effector_link" />
+          <child  link="${prefix}camera_link" />
+        </joint>
+        <link name="${prefix}camera_depth_frame" />
+        <joint name="${prefix}depth_module" type="fixed">
+          <origin xyz="0.0275 0.066 0.01305" rpy="0 -1.570796326794897 -1.570796326794897" />
+          <parent link="${prefix}end_effector_link" />
+          <child  link="${prefix}camera_depth_frame" />
+        </joint>
+        <link name="${prefix}camera_color_frame" />
+        <joint name="${prefix}color_module" type="fixed">
+          <origin xyz="0 0.05639 0.01305" rpy="0 -1.570796326794897 -1.570796326794897" />
+          <parent link="${prefix}end_effector_link" />
+          <child  link="${prefix}camera_color_frame" />
+        </joint>
+      </xacro:unless>
     </xacro:if>
   </xacro:macro>
 </robot>

--- a/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
+++ b/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
@@ -296,7 +296,7 @@
           <mesh filename="file://$(find kortex_description)/arms/gen3/${dof}dof/meshes/bracelet_with_vision_link.STL" />
         </geometry>
         <material name="">
-          <color rgba="0.75294 0.75294 0.75294 1" />
+          <color rgba="0.75294 0 0 1" />
         </material>
       </visual>
       <collision>
@@ -361,19 +361,19 @@
     <xacro:if value="${vision}">
       <link name="${prefix}camera_link" />
       <joint name="${prefix}camera_module" type="fixed">
-        <origin xyz="0 0.05639 -0.00305" rpy="3.14159265358979 3.14159265358979 0" />
+        <origin xyz="0 0.05639 0.01305" rpy="0 -1.570796326794897 -1.570796326794897" />
         <parent link="${prefix}end_effector_link" />
         <child  link="${prefix}camera_link" />
       </joint>
       <link name="${prefix}camera_depth_frame" />
       <joint name="${prefix}depth_module" type="fixed">
-        <origin xyz="0.0275 0.066 -0.00305" rpy="3.14159265358979 3.14159265358979 0" />
+        <origin xyz="0.0275 0.066 0.01305" rpy="0 -1.570796326794897 -1.570796326794897" />
         <parent link="${prefix}end_effector_link" />
         <child  link="${prefix}camera_depth_frame" />
       </joint>
       <link name="${prefix}camera_color_frame" />
       <joint name="${prefix}color_module" type="fixed">
-        <origin xyz="0 0.05639 -0.00305" rpy="3.14159265358979 3.14159265358979 0" />
+        <origin xyz="0 0.05639 0.01305" rpy="0 -1.570796326794897 -1.570796326794897" />
         <parent link="${prefix}end_effector_link" />
         <child  link="${prefix}camera_color_frame" />
       </joint>

--- a/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
+++ b/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
@@ -4,6 +4,7 @@
 
   <!-- Propagate last link name information because it is the gripper's parent link -->
   <xacro:property name="last_arm_link" value="end_effector_link"/>
+  <xacro:property name="PI" value="3.1415926535897931"/>
 
   <xacro:macro name="load_arm" params="
     parent
@@ -363,19 +364,19 @@
       <xacro:if value="${sim_ignition}">
         <link name="${prefix}camera_link" />
         <joint name="${prefix}camera_module" type="fixed">
-          <origin xyz="0 0.05639 0.01305" rpy="0 -1.570796326794897 -1.570796326794897" />
+          <origin xyz="0 0.05639 0.01305" rpy="0 ${-PI/2} ${-PI/2}" />
           <parent link="${prefix}end_effector_link" />
           <child  link="${prefix}camera_link" />
         </joint>
         <link name="${prefix}camera_depth_frame" />
         <joint name="${prefix}depth_module" type="fixed">
-          <origin xyz="0.0275 0.066 0.01305" rpy="0 -1.570796326794897 -1.570796326794897" />
+          <origin xyz="0.0275 0.066 0.01305" rpy="0 ${-PI/2} ${-PI/2}" />
           <parent link="${prefix}end_effector_link" />
           <child  link="${prefix}camera_depth_frame" />
         </joint>
         <link name="${prefix}camera_color_frame" />
         <joint name="${prefix}color_module" type="fixed">
-          <origin xyz="0 0.05639 0.01305" rpy="0 -1.570796326794897 -1.570796326794897" />
+          <origin xyz="0 0.05639 0.01305" rpy="0 ${-PI/2} ${-PI/2}" />
           <parent link="${prefix}end_effector_link" />
           <child  link="${prefix}camera_color_frame" />
         </joint>
@@ -383,19 +384,19 @@
       <xacro:unless value="${sim_ignition}">
         <link name="${prefix}camera_link" />
         <joint name="${prefix}camera_module" type="fixed">
-          <origin xyz="0 0.05639 0.01305" rpy="0 -1.570796326794897 -1.570796326794897" />
+          <origin xyz="0 0.05639 -0.00305" rpy="${PI} ${PI} 0" />
           <parent link="${prefix}end_effector_link" />
           <child  link="${prefix}camera_link" />
         </joint>
         <link name="${prefix}camera_depth_frame" />
         <joint name="${prefix}depth_module" type="fixed">
-          <origin xyz="0.0275 0.066 0.01305" rpy="0 -1.570796326794897 -1.570796326794897" />
+          <origin xyz="0.0275 0.066 -0.00305" rpy="${PI} ${PI} 0" />
           <parent link="${prefix}end_effector_link" />
           <child  link="${prefix}camera_depth_frame" />
         </joint>
         <link name="${prefix}camera_color_frame" />
         <joint name="${prefix}color_module" type="fixed">
-          <origin xyz="0 0.05639 0.01305" rpy="0 -1.570796326794897 -1.570796326794897" />
+          <origin xyz="0 0.05639 -0.00305" rpy="${PI} ${PI} 0" />
           <parent link="${prefix}end_effector_link" />
           <child  link="${prefix}camera_color_frame" />
         </joint>

--- a/kortex_description/robots/kinova.urdf.xacro
+++ b/kortex_description/robots/kinova.urdf.xacro
@@ -24,8 +24,9 @@
   <xacro:arg name="sim_ignition" default="false" />
   <xacro:arg name="sim_isaac" default="false" />
   <xacro:arg name="gazebo_renderer" default="ogre"/>
-  <xacro:arg name="gazebo_camera_fps" default="6"/>
-  <xacro:arg name="simulate_depth" default="true"/>
+  <xacro:arg name="camera_width" default="640"/>
+  <xacro:arg name="camera_height" default="480"/>
+  <xacro:arg name="camera_fps" default="6"/>
   <xacro:arg name="simulation_controllers" default="$(find kortex_description)/arm/$(arg arm)/$(arg dof)dof/config/ros2_controllers.yaml" />
 
 
@@ -70,13 +71,6 @@
   </xacro:if>
 
   <xacro:if value="$(arg sim_ignition)">
-    <!-- Configure simulated camera -->
-    <xacro:if value="$(arg simulate_depth)">
-      <xacro:property name="sim_sensor_type" value="rgbd_camera" />
-    </xacro:if>
-    <xacro:unless value="$(arg simulate_depth)">
-      <xacro:property name="sim_sensor_type" value="camera" />
-    </xacro:unless>
     <!-- Gazebo plugins -->
     <gazebo reference="world">
     </gazebo>
@@ -90,12 +84,12 @@
       </plugin>
     </gazebo>
     <gazebo reference="camera_color_frame">
-      <sensor name="camera_sensor" type="${sim_sensor_type}">
+      <sensor name="camera_sensor" type="rgbd_camera">
         <camera>
           <horizontal_fov>1.047</horizontal_fov>
           <image>
-            <width>640</width>
-            <height>480</height>
+            <width>$(arg camera_width)</width>
+            <height>$(arg camera_height)</height>
             <format>RGB_INT8</format>
           </image>
           <clip>
@@ -134,19 +128,17 @@
             <mean>0</mean>
             <stddev>0.00</stddev>
           </noise>
-          <xacro:if value="$(arg simulate_depth)">
-            <depth_camera>
-              <clip>
-                <near>0.25</near>
-                <far>5</far>
-              </clip>
-            </depth_camera>
-          </xacro:if>
+          <depth_camera>
+            <clip>
+              <near>0.25</near>
+              <far>5</far>
+            </clip>
+          </depth_camera>
           <optical_frame_id>color_optical_frame</optical_frame_id>
         </camera>
         <ignition_frame_id>camera_color_frame</ignition_frame_id>
         <always_on>1</always_on>
-        <update_rate>$(arg gazebo_camera_fps)</update_rate>
+        <update_rate>$(arg camera_fps)</update_rate>
         <visualize>true</visualize>
         <topic>wrist_mounted_camera</topic>
         <enable_metrics>false</enable_metrics>

--- a/kortex_description/robots/kinova.urdf.xacro
+++ b/kortex_description/robots/kinova.urdf.xacro
@@ -23,6 +23,9 @@
   <xacro:arg name="sim_gazebo" default="false" />
   <xacro:arg name="sim_ignition" default="false" />
   <xacro:arg name="sim_isaac" default="false" />
+  <xacro:arg name="gazebo_renderer" default="ogre"/>
+  <xacro:arg name="gazebo_camera_fps" default="6"/>
+  <xacro:arg name="simulate_depth" default="true"/>
   <xacro:arg name="simulation_controllers" default="$(find kortex_description)/arm/$(arg arm)/$(arg dof)dof/config/ros2_controllers.yaml" />
 
 
@@ -67,6 +70,13 @@
   </xacro:if>
 
   <xacro:if value="$(arg sim_ignition)">
+    <!-- Configure simulated camera -->
+    <xacro:if value="$(arg simulate_depth)">
+      <xacro:property name="sim_sensor_type" value="rgbd_camera" />
+    </xacro:if>
+    <xacro:unless value="$(arg simulate_depth)">
+      <xacro:property name="sim_sensor_type" value="camera" />
+    </xacro:unless>
     <!-- Gazebo plugins -->
     <gazebo reference="world">
     </gazebo>
@@ -75,7 +85,74 @@
         <parameters>$(arg simulation_controllers)</parameters>
         <controller_manager_node_name>$(arg prefix)controller_manager</controller_manager_node_name>
       </plugin>
+      <plugin filename="libignition-gazebo-sensors-system.so" name="ignition::gazebo::systems::Sensors">
+        <render_engine>$(arg gazebo_renderer)</render_engine>
+      </plugin>
+    </gazebo>
+    <gazebo reference="camera_color_frame">
+      <sensor name="camera_sensor" type="${sim_sensor_type}">
+        <camera>
+          <horizontal_fov>1.047</horizontal_fov>
+          <image>
+            <width>640</width>
+            <height>480</height>
+            <format>RGB_INT8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>5</far>
+          </clip>
+          <distortion>
+            <k1>0.0</k1>
+            <k2>0.0</k2>
+            <k3>0.0</k3>
+            <p1>0.0</p1>
+            <p2>0.0</p2>
+            <center>0.5 0.5</center>
+          </distortion>
+          <lens>
+            <intrinsics>
+              <fx>554.25469</fx>
+              <fy>554.25469</fy>
+              <cx>320.5</cx>
+              <cy>240.5</cy>
+              <s>0</s>
+            </intrinsics>
+            <!-- These need to match the intrinsics above or
+            Ignition will default to different default values -->
+            <projection>
+              <p_fx>554.25469</p_fx>
+              <p_fy>554.25469</p_fy>
+              <p_cx>320.5</p_cx>
+              <p_cy>240.5</p_cy>
+              <tx>0</tx>
+              <ty>0</ty>
+            </projection>
+          </lens>
+          <noise>
+            <type>gaussian</type>
+            <mean>0</mean>
+            <stddev>0.00</stddev>
+          </noise>
+          <xacro:if value="$(arg simulate_depth)">
+            <depth_camera>
+              <clip>
+                <near>0.25</near>
+                <far>5</far>
+              </clip>
+            </depth_camera>
+          </xacro:if>
+          <optical_frame_id>color_optical_frame</optical_frame_id>
+        </camera>
+        <ignition_frame_id>camera_color_frame</ignition_frame_id>
+        <always_on>1</always_on>
+        <update_rate>$(arg gazebo_camera_fps)</update_rate>
+        <visualize>true</visualize>
+        <topic>wrist_mounted_camera</topic>
+        <enable_metrics>false</enable_metrics>
+      </sensor>
     </gazebo>
   </xacro:if>
 
 </robot>
+

--- a/kortex_description/robots/kinova.urdf.xacro
+++ b/kortex_description/robots/kinova.urdf.xacro
@@ -155,4 +155,3 @@
   </xacro:if>
 
 </robot>
-

--- a/kortex_description/rviz/view_robot.rviz
+++ b/kortex_description/rviz/view_robot.rviz
@@ -81,6 +81,10 @@ Visualization Manager:
           Alpha: 1
           Show Axes: false
           Show Trail: false
+        color_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
         end_effector_link:
           Alpha: 1
           Show Axes: false

--- a/kortex_description/rviz/view_robot.rviz
+++ b/kortex_description/rviz/view_robot.rviz
@@ -81,10 +81,6 @@ Visualization Manager:
           Alpha: 1
           Show Axes: false
           Show Trail: false
-        color_optical_frame:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
         end_effector_link:
           Alpha: 1
           Show Axes: false

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/config/gen3.srdf
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/config/gen3.srdf
@@ -30,6 +30,33 @@
     <group_state name="Close" group="gripper">
         <joint name="robotiq_85_left_knuckle_joint" value="0.8"/>
     </group_state>
+        <group_state name="home" group="manipulator">
+        <joint name="joint_1" value="0" />
+        <joint name="joint_2" value="0.26" />
+        <joint name="joint_3" value="3.14" />
+        <joint name="joint_4" value="-2.27" />
+        <joint name="joint_5" value="0" />
+        <joint name="joint_6" value="0.96" />
+        <joint name="joint_7" value="1.57" />
+    </group_state>
+    <group_state name="retract" group="manipulator">
+        <joint name="joint_1" value="0" />
+        <joint name="joint_2" value="-0.35" />
+        <joint name="joint_3" value="3.14" />
+        <joint name="joint_4" value="-2.54" />
+        <joint name="joint_5" value="0" />
+        <joint name="joint_6" value="-0.87" />
+        <joint name="joint_7" value="1.57" />
+    </group_state>
+    <group_state name="vertical" group="manipulator">
+        <joint name="joint_1" value="0" />
+        <joint name="joint_2" value="0" />
+        <joint name="joint_3" value="0" />
+        <joint name="joint_4" value="0" />
+        <joint name="joint_5" value="0" />
+        <joint name="joint_6" value="0" />
+        <joint name="joint_7" value="0" />
+    </group_state>
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
     <end_effector name="gripper" parent_link="base_link" group="gripper"/>
     <!--PASSIVE JOINT: Purpose: this element is used to mark joints that are not actuated-->

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
@@ -73,9 +73,7 @@ def generate_launch_description():
     moveit_config = (
         MoveItConfigsBuilder("gen3", package_name="kinova_gen3_7dof_robotiq_2f_85_moveit_config")
         .robot_description(mappings=description_arguments)
-        .planning_pipelines(
-            pipelines=["ompl", "pilz_industrial_motion_planner", "stomp"]
-        )
+        .planning_pipelines(pipelines=["ompl", "pilz_industrial_motion_planner", "stomp"])
         .to_moveit_configs()
     )
 

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
@@ -48,7 +48,7 @@ def generate_launch_description():
         DeclareLaunchArgument(
             "vision",
             default_value="false",
-            description="Use simulated clock",
+            description="Add vision module to URDF",
         )
     )
     declared_arguments.append(

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
@@ -40,7 +40,14 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "use_sim_time",
-            default_value="False",
+            default_value="true",
+            description="Use simulated clock",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "vision",
+            default_value="false",
             description="Use simulated clock",
         )
     )
@@ -52,6 +59,7 @@ def generate_launch_description():
     launch_rviz = LaunchConfiguration("launch_rviz")
     use_sim_time = LaunchConfiguration("use_sim_time")
     sim_ignition = LaunchConfiguration("sim_ignition")
+    vision = LaunchConfiguration("vision")
 
     description_arguments = {
         "robot_ip": "xxx.yyy.zzz.www",
@@ -59,12 +67,15 @@ def generate_launch_description():
         "gripper": "robotiq_2f_85",
         "dof": "7",
         "sim_ignition": sim_ignition,
+        "vision": vision,
     }
 
     moveit_config = (
         MoveItConfigsBuilder("gen3", package_name="kinova_gen3_7dof_robotiq_2f_85_moveit_config")
         .robot_description(mappings=description_arguments)
-        .planning_scene_monitor(publish_robot_description=True)
+        .planning_pipelines(
+            pipelines=["ompl", "pilz_industrial_motion_planner", "stomp"]
+        )
         .to_moveit_configs()
     )
 


### PR DESCRIPTION
Adds the necessary gazebo plugins to use the simulated real sense in Ignition simulation of the 7dof Kinova Gen3. Also adds a few poses to the 7dof Gen3 MoveIt config

**Testing:**

1. Launch the arm in Ignition using the following command: 
```ros2 launch kortex2_bringup kortex_sim_control.launch.py vision:=true use_sim_time:=true launch_rviz:=false```
2. Launch MoveIt and Rviz with the following command:
```ros2 launch kinova_gen3_7dof_robotiq_2f_85_moveit_config sim.launch.py use_sim_time:=true vision:=true sim_ignition:=true```
3. View the camera feed in Rviz by clicking "Add" > "By topic" > "/wrist_camera_mounted/image" > "Image"
4. Move the arm to a desired pose (I used the predefined "home" pose)
5. place an object in front of the end effector. You should be able to view it from the Rviz camera.

https://github.com/PickNikRobotics/ros2_kortex/assets/7244387/27123397-357b-486a-a6f8-f8b51dd1453b


https://github.com/PickNikRobotics/ros2_kortex/assets/7244387/e1da24bf-827c-442a-bc0c-03d74cf71d9c


https://github.com/PickNikRobotics/ros2_kortex/assets/7244387/fab20d3d-f2c2-4596-95ab-8750525bd243

