### PR TITLE
Fix License -> BSD and update maintainers

### DIFF
--- a/kortex_bringup/package.xml
+++ b/kortex_bringup/package.xml
@@ -9,7 +9,7 @@
 
   <maintainer email="marq.rasmussen@picknik.ai">Marq Rasmussen</maintainer>
 
-  <license>Proprietary</license>
+  <license>BSD</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>

--- a/kortex_driver/package.xml
+++ b/kortex_driver/package.xml
@@ -4,8 +4,11 @@
   <name>kortex_driver</name>
   <version>0.0.0</version>
   <description>ROS2 driver package for the Kinova Robot Hardware.</description>
+  <maintainer email="alex.moriarty@picknik.ai">Alex Moriarty</maintainer>
+  <maintainer email="fmaisonneuve@kinova.ca">Felix Maisonneuve</maintainer>
+  <maintainer email="mleroux@kinova.ca">Martin Leroux</maintainer>
   <maintainer email="marq.rasmussen@picknik.ai">Marq Rasmussen</maintainer>
-  <license>Proprietary</license>
+  <license>BSD</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 


### PR DESCRIPTION
- related to: https://github.com/ros/rosdistro/pull/37893
  - Fixes the license in the package.xml they should be BSD
  - The top level package is BSD
- related to: https://github.com/ros2-gbp/ros2-gbp-github-org/issues/291
  - And to: https://github.com/ros2-gbp/ros2-gbp-github-org/pull/294
  - Adds @moriarty @felixmaisonneuve and @martinleroux