### PR TITLE
remove stomp for Humble from ros packages

### DIFF
--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/sim.launch.py
@@ -73,7 +73,7 @@ def generate_launch_description():
     moveit_config = (
         MoveItConfigsBuilder("gen3", package_name="kinova_gen3_7dof_robotiq_2f_85_moveit_config")
         .robot_description(mappings=description_arguments)
-        .planning_pipelines(pipelines=["ompl", "pilz_industrial_motion_planner", "stomp"])
+        .planning_pipelines(pipelines=["ompl", "pilz_industrial_motion_planner"])
         .to_moveit_configs()
     )
 


### PR DESCRIPTION
- STOMP is available if you build and use MoveIt from src but not if you have MoveIt installed from the ros distro