### PR TITLE
Add use_external_cable parameter to URDF

### DIFF
--- a/kortex_description/arms/gen3/6dof/urdf/gen3_macro.xacro
+++ b/kortex_description/arms/gen3/6dof/urdf/gen3_macro.xacro
@@ -317,7 +317,7 @@
       </collision>
     </link>
     </xacro:unless>
-    <xacro:if value="${use_external_cable">
+    <xacro:if value="${use_external_cable}">
       <joint name="${prefix}joint_6" type="revolute">
         <origin xyz="0 0.10593 -0.00017505" rpy="1.5708 0.0 0.0" />
         <parent link="${prefix}spherical_wrist_2_link" />
@@ -326,7 +326,7 @@
         <limit lower="${-2*PI}" upper="${2*PI}" effort="9" velocity="1.2218" />
       </joint>
     </xacro:if>
-    <xacro:unless value="${use_external_cable">
+    <xacro:unless value="${use_external_cable}">
       <joint name="${prefix}joint_6" type="continuous">
         <origin xyz="0 0.10593 -0.00017505" rpy="1.5708 0.0 0.0" />
         <parent link="${prefix}spherical_wrist_2_link" />

--- a/kortex_description/arms/gen3/6dof/urdf/gen3_macro.xacro
+++ b/kortex_description/arms/gen3/6dof/urdf/gen3_macro.xacro
@@ -4,6 +4,7 @@
 
   <!-- Propagate last link name information because it is the gripper's parent link -->
   <xacro:property name="last_arm_link" value="end_effector_link"/>
+  <xacro:property name="PI" value="3.1415926535897931"/>
 
   <xacro:macro name="load_arm" params="
     parent
@@ -24,6 +25,7 @@
     sim_gazebo:=false
     sim_ignition:=false
     sim_isaac:=false
+    use_external_cable:=false
     initial_positions:=${dict(joint_1=0.0,joint_2=0.0,joint_3=0.0,joint_4=0.0,joint_5=0.0,joint_6=0.0)}" >
 
     <!-- ros2 control include -->
@@ -95,19 +97,39 @@
         </geometry>
       </collision>
     </link>
-    <joint
-      name="${prefix}joint_1"
-      type="continuous">
-      <origin
-        xyz="0 0 0.15643"
-        rpy="-3.1416 0.0 0.0" />
-      <parent link="${prefix}base_link" />
-      <child link="${prefix}shoulder_link" />
-      <axis xyz="0 0 1" />
-      <limit
-        effort="39"
-        velocity="1.3963" />
-    </joint>
+    <xacro:if value="${use_external_cable}">
+      <joint
+        name="${prefix}joint_1"
+        type="revolute">
+        <origin
+          xyz="0 0 0.15643"
+          rpy="-3.1416 0.0 0.0" />
+        <parent link="${prefix}base_link" />
+        <child link="${prefix}shoulder_link" />
+        <axis xyz="0 0 1" />
+        <limit
+          lower="${-2*PI}"
+          upper="${2*PI}"
+          effort="39"
+          velocity="1.3963" />
+      </joint>
+    </xacro:if>
+    <xacro:unless value="${use_external_cable}">
+      <joint
+        name="${prefix}joint_1"
+        type="continuous">
+        <origin
+          xyz="0 0 0.15643"
+          rpy="-3.1416 0.0 0.0" />
+        <parent link="${prefix}base_link" />
+        <child link="${prefix}shoulder_link" />
+        <axis xyz="0 0 1" />
+        <limit
+          effort="39"
+          velocity="1.3963" />
+      </joint>
+    </xacro:unless>
+
     <link name="${prefix}bicep_link">
       <inertial>
         <origin
@@ -200,13 +222,24 @@
         </geometry>
       </collision>
     </link>
-    <joint name="${prefix}joint_4" type="continuous">
-      <origin xyz="0 0.20843 -0.006375" rpy="1.5708 0.0 0.0" />
-      <parent link="${prefix}forearm_link" />
-      <child link="${prefix}spherical_wrist_1_link" />
-      <axis xyz="0 0 1" />
-      <limit effort="9" velocity="1.2218" />
-    </joint>
+    <xacro:if value="${use_external_cable}">
+      <joint name="${prefix}joint_4" type="revolute">
+        <origin xyz="0 0.20843 -0.006375" rpy="1.5708 0.0 0.0" />
+        <parent link="${prefix}forearm_link" />
+        <child link="${prefix}spherical_wrist_1_link" />
+        <axis xyz="0 0 1" />
+        <limit lower="${-2*PI}" upper="${2*PI}" effort="9" velocity="1.2218" />
+      </joint>
+    </xacro:if>
+    <xacro:unless value="${use_external_cable}">
+      <joint name="${prefix}joint_4" type="continuous">
+        <origin xyz="0 0.20843 -0.006375" rpy="1.5708 0.0 0.0" />
+        <parent link="${prefix}forearm_link" />
+        <child link="${prefix}spherical_wrist_1_link" />
+        <axis xyz="0 0 1" />
+        <limit effort="9" velocity="1.2218" />
+      </joint>
+    </xacro:unless>
     <link name="${prefix}spherical_wrist_2_link">
       <inertial>
         <origin xyz="-1E-06 0.046429 -0.008704" rpy="0 0 0" />
@@ -284,13 +317,24 @@
       </collision>
     </link>
     </xacro:unless>
-    <joint name="${prefix}joint_6" type="continuous">
-      <origin xyz="0 0.10593 -0.00017505" rpy="1.5708 0.0 0.0" />
-      <parent link="${prefix}spherical_wrist_2_link" />
-      <child link="${prefix}bracelet_link" />
-      <axis xyz="0 0 1" />
-      <limit effort="9" velocity="1.2218" />
-    </joint>
+    <xacro:if value="${use_external_cable">
+      <joint name="${prefix}joint_6" type="revolute">
+        <origin xyz="0 0.10593 -0.00017505" rpy="1.5708 0.0 0.0" />
+        <parent link="${prefix}spherical_wrist_2_link" />
+        <child link="${prefix}bracelet_link" />
+        <axis xyz="0 0 1" />
+        <limit lower="${-2*PI}" upper="${2*PI}" effort="9" velocity="1.2218" />
+      </joint>
+    </xacro:if>
+    <xacro:unless value="${use_external_cable">
+      <joint name="${prefix}joint_6" type="continuous">
+        <origin xyz="0 0.10593 -0.00017505" rpy="1.5708 0.0 0.0" />
+        <parent link="${prefix}spherical_wrist_2_link" />
+        <child link="${prefix}bracelet_link" />
+        <axis xyz="0 0 1" />
+        <limit effort="9" velocity="1.2218" />
+      </joint>
+    </xacro:unless>
     <link name="${prefix}end_effector_link" />
     <joint
       name="${prefix}end_effector"

--- a/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
+++ b/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
@@ -301,7 +301,7 @@
           velocity="1.2218" />
       </joint>
     </xacro:if>
-    <xacro:unless value="${use_external_cable">
+    <xacro:unless value="${use_external_cable}">
       <joint
         name="${prefix}joint_5"
         type="continuous">
@@ -399,7 +399,7 @@
       </collision>
     </link>
     </xacro:unless>
-    <xacro:if value="${use_external_cable">
+    <xacro:if value="${use_external_cable}">
       <joint
         name="${prefix}joint_7"
         type="revolute">
@@ -417,7 +417,7 @@
           velocity="1.2218" />
       </joint>
     </xacro:if>
-    <xacro:unless value="${use_external_cable">
+    <xacro:unless value="${use_external_cable}">
       <joint
         name="${prefix}joint_7"
         type="continuous">

--- a/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
+++ b/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
@@ -28,6 +28,7 @@
     sim_gazebo:=false
     sim_ignition:=false
     sim_isaac:=false
+    use_external_cable:=false
     initial_positions:=${dict(joint_1=0.0,joint_2=0.0,joint_3=0.0,joint_4=0.0,joint_5=0.0,joint_6=0.0,joint_7=0.0)}" >
 
     <!-- ros2 control include -->
@@ -102,20 +103,40 @@
         </geometry>
       </collision>
     </link>
-    <joint
+    <xacro:if value="${use_external_cable}">
+      <joint
       name="${prefix}joint_1"
-      type="continuous">
-      <origin xyz="0 0 0.15643" rpy="3.1416 2.7629E-18 -4.9305E-36" />
-      <parent
-        link="${prefix}base_link" />
-      <child
-        link="${prefix}shoulder_link" />
-      <axis
-        xyz="0 0 1" />
-      <limit
-        effort="39"
-        velocity="1.3963" />
-    </joint>
+      type="revolute">
+        <origin xyz="0 0 0.15643" rpy="3.1416 2.7629E-18 -4.9305E-36" />
+        <parent
+          link="${prefix}base_link" />
+        <child
+          link="${prefix}shoulder_link" />
+        <axis
+          xyz="0 0 1" />
+        <limit
+          lower="${-2*PI}"
+          upper="${2*PI}"
+          effort="39"
+          velocity="1.3963" />
+      </joint>
+    </xacro:if>
+    <xacro:unless value="${use_external_cable}">
+      <joint
+        name="${prefix}joint_1"
+        type="continuous">
+        <origin xyz="0 0 0.15643" rpy="3.1416 2.7629E-18 -4.9305E-36" />
+        <parent
+          link="${prefix}base_link" />
+        <child
+          link="${prefix}shoulder_link" />
+        <axis
+          xyz="0 0 1" />
+        <limit
+          effort="39"
+          velocity="1.3963" />
+      </joint>
+    </xacro:unless>
     <link name="${prefix}half_arm_1_link">
       <inertial>
         <origin xyz="-4.4E-05 -0.09958 -0.013278" rpy="0 0 0" />
@@ -172,20 +193,40 @@
         </geometry>
       </collision>
     </link>
-    <joint
-      name="${prefix}joint_3"
-      type="continuous">
-      <origin xyz="0 -0.21038 -0.006375" rpy="-1.5708 1.2326E-32 -2.9122E-16" />
-      <parent
-        link="${prefix}half_arm_1_link" />
-      <child
-        link="${prefix}half_arm_2_link" />
-      <axis
-        xyz="0 0 1" />
-      <limit
-        effort="39"
-        velocity="1.3963" />
-    </joint>
+    <xacro:if value="${use_external_cable}">
+      <joint
+        name="${prefix}joint_3"
+        type="revolute">
+        <origin xyz="0 -0.21038 -0.006375" rpy="-1.5708 1.2326E-32 -2.9122E-16" />
+        <parent
+          link="${prefix}half_arm_1_link" />
+        <child
+          link="${prefix}half_arm_2_link" />
+        <axis
+          xyz="0 0 1" />
+        <limit
+          lower="${-2*PI}"
+          upper="${2*PI}"
+          effort="39"
+          velocity="1.3963" />
+      </joint>
+    </xacro:if>
+    <xacro:unless value="${use_external_cable}">
+      <joint
+        name="${prefix}joint_3"
+        type="continuous">
+        <origin xyz="0 -0.21038 -0.006375" rpy="-1.5708 1.2326E-32 -2.9122E-16" />
+        <parent
+          link="${prefix}half_arm_1_link" />
+        <child
+          link="${prefix}half_arm_2_link" />
+        <axis
+          xyz="0 0 1" />
+        <limit
+          effort="39"
+          velocity="1.3963" />
+      </joint>
+    </xacro:unless>
     <link name="${prefix}forearm_link">
       <inertial>
         <origin xyz="-1.8E-05 -0.075478 -0.015006" rpy="0 0 0" />
@@ -242,20 +283,40 @@
         </geometry>
       </collision>
     </link>
-    <joint
-      name="${prefix}joint_5"
-      type="continuous">
-      <origin xyz="0 -0.20843 -0.006375" rpy="-1.5708 2.2204E-16 -6.373E-17" />
-      <parent
-        link="${prefix}forearm_link" />
-      <child
-        link="${prefix}spherical_wrist_1_link" />
-      <axis
-        xyz="0 0 1" />
-      <limit
-        effort="9"
-        velocity="1.2218" />
-    </joint>
+    <xacro:if value="${use_external_cable}">
+      <joint
+        name="${prefix}joint_5"
+        type="revolute">
+        <origin xyz="0 -0.20843 -0.006375" rpy="-1.5708 2.2204E-16 -6.373E-17" />
+        <parent
+          link="${prefix}forearm_link" />
+        <child
+          link="${prefix}spherical_wrist_1_link" />
+        <axis
+          xyz="0 0 1" />
+        <limit
+          lower="${-2*PI}"
+          upper="${2*PI}"
+          effort="9"
+          velocity="1.2218" />
+      </joint>
+    </xacro:if>
+    <xacro:unless value="${use_external_cable">
+      <joint
+        name="${prefix}joint_5"
+        type="continuous">
+        <origin xyz="0 -0.20843 -0.006375" rpy="-1.5708 2.2204E-16 -6.373E-17" />
+        <parent
+          link="${prefix}forearm_link" />
+        <child
+          link="${prefix}spherical_wrist_1_link" />
+        <axis
+          xyz="0 0 1" />
+        <limit
+          effort="9"
+          velocity="1.2218" />
+      </joint>
+    </xacro:unless>
     <link name="${prefix}spherical_wrist_2_link">
       <inertial>
         <origin xyz="1E-06 -0.045483 -0.00965" rpy="0 0 0" />
@@ -338,20 +399,40 @@
       </collision>
     </link>
     </xacro:unless>
-    <joint
-      name="${prefix}joint_7"
-      type="continuous">
-      <origin xyz="0 -0.10593 -0.00017505" rpy="-1.5708 -5.5511E-17 9.6396E-17" />
-      <parent
-        link="${prefix}spherical_wrist_2_link" />
-      <child
-        link="${prefix}bracelet_link" />
-      <axis
-        xyz="0 0 1" />
-      <limit
-        effort="9"
-        velocity="1.2218" />
-    </joint>
+    <xacro:if value="${use_external_cable">
+      <joint
+        name="${prefix}joint_7"
+        type="revolute">
+        <origin xyz="0 -0.10593 -0.00017505" rpy="-1.5708 -5.5511E-17 9.6396E-17" />
+        <parent
+          link="${prefix}spherical_wrist_2_link" />
+        <child
+          link="${prefix}bracelet_link" />
+        <axis
+          xyz="0 0 1" />
+        <limit
+          lower="${-2*PI}"
+          upper="${2*PI}"
+          effort="9"
+          velocity="1.2218" />
+      </joint>
+    </xacro:if>
+    <xacro:unless value="${use_external_cable">
+      <joint
+        name="${prefix}joint_7"
+        type="continuous">
+        <origin xyz="0 -0.10593 -0.00017505" rpy="-1.5708 -5.5511E-17 9.6396E-17" />
+        <parent
+          link="${prefix}spherical_wrist_2_link" />
+        <child
+          link="${prefix}bracelet_link" />
+        <axis
+          xyz="0 0 1" />
+        <limit
+          effort="9"
+          velocity="1.2218" />
+      </joint>
+    </xacro:unless>
     <link name="${prefix}end_effector_link" />
     <joint
       name="${prefix}end_effector"

--- a/kortex_description/robots/gen3.xacro
+++ b/kortex_description/robots/gen3.xacro
@@ -24,6 +24,7 @@
     <xacro:arg name="use_fake_hardware" default="false" />
     <xacro:arg name="fake_sensor_commands" default="false" />
     <xacro:arg name="use_internal_bus_gripper_comm" default="false" />
+    <xacro:arg name="use_external_cable" default="false" />
 
     <xacro:include filename="$(find kortex_description)/robots/kortex_robot.xacro" />
     <link name="world" />
@@ -49,7 +50,8 @@
         fake_sensor_commands="$(arg fake_sensor_commands)"
         sim_gazebo="$(arg sim_gazebo)"
         sim_ignition="$(arg sim_ignition)"
-        sim_isaac="$(arg sim_isaac)" >
+        sim_isaac="$(arg sim_isaac)"
+        use_external_cable="$(arg use_external_cable)" >
         <origin xyz="0 0 0" rpy="0 0 0" />  <!-- position robot in the world -->
     </xacro:load_robot>
 

--- a/kortex_description/robots/kortex_robot.xacro
+++ b/kortex_description/robots/kortex_robot.xacro
@@ -24,6 +24,7 @@
     sim_gazebo:=false
     sim_ignition:=false
     sim_isaac:=false
+    use_external_cable:=false
     gripper_max_velocity:=100.0
     gripper_max_force:=100.0">
 
@@ -51,7 +52,8 @@
       sim_isaac="${sim_isaac}"
       gripper_joint_name="${gripper_joint_name}"
       gripper_max_velocity="${gripper_max_velocity}"
-      gripper_max_force="${gripper_max_force}">
+      gripper_max_force="${gripper_max_force}"
+      use_external_cable="${use_external_cable}">
       <xacro:insert_block name="origin" />
     </xacro:load_arm>
 

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
@@ -52,6 +52,14 @@ def generate_launch_description():
 
     declared_arguments.append(
         DeclareLaunchArgument(
+            "use_external_cable",
+            default_value="false",
+            description="Max force for gripper commands",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
             "use_sim_time",
             default_value="false",
             description="Use simulated clock",
@@ -63,6 +71,7 @@ def generate_launch_description():
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
     gripper_max_velocity = LaunchConfiguration("gripper_max_velocity")
     gripper_max_force = LaunchConfiguration("gripper_max_force")
+    use_external_cable = LaunchConfiguration("use_external_cable")
 
     launch_arguments = {
         "robot_ip": robot_ip,
@@ -72,6 +81,7 @@ def generate_launch_description():
         "dof": "7",
         "gripper_max_velocity": gripper_max_velocity,
         "gripper_max_force": gripper_max_force,
+        "use_external_cable": use_external_cable,
     }
 
     moveit_config = (


### PR DESCRIPTION
When set to true, this parameter will set artificial joints limits of [-2PI, 2PI] on all continuous joints. 

Testing:
- Launch robot with MoveIt, setting `use_external_cable:=true`
- In RVIZ under the "Motion Planning" widget, select the joints tab and observe that the continuous joints have the limits set.

