### PR TITLE
Change kortex_api header and library install locations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -110,7 +110,7 @@ repos:
         entry: ament_lint_cmake
         language: system
         files: CMakeLists\.txt$
-        exclude: kortex_api/
+        exclude: '(kortex_api|kortex_driver)/.*'
 
   # Copyright
   - repo: local

--- a/kortex_api/CMakeLists.txt
+++ b/kortex_api/CMakeLists.txt
@@ -35,15 +35,12 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
-ament_export_libraries(${kinova_binary_api_SOURCE_DIR}/lib/release/libKortexApiCpp.a)
-link_libraries(pthread)
+ament_export_include_directories(include/kortex_api)
 
-ament_export_include_directories(include)
-
-install(DIRECTORY ${kinova_binary_api_SOURCE_DIR}/include/client/ DESTINATION include)
-install(DIRECTORY ${kinova_binary_api_SOURCE_DIR}/include/common/ DESTINATION include)
-install(DIRECTORY ${kinova_binary_api_SOURCE_DIR}/include/messages/ DESTINATION include)
-install(DIRECTORY ${kinova_binary_api_SOURCE_DIR}/include/client_stubs/ DESTINATION include)
-install(DIRECTORY ${kinova_binary_api_SOURCE_DIR}/include/google/protobuf DESTINATION include/google)
+install(DIRECTORY ${kinova_binary_api_SOURCE_DIR}/include/client/ DESTINATION include/kortex_api)
+install(DIRECTORY ${kinova_binary_api_SOURCE_DIR}/include/common/ DESTINATION include/kortex_api)
+install(DIRECTORY ${kinova_binary_api_SOURCE_DIR}/include/messages/ DESTINATION include/kortex_api)
+install(DIRECTORY ${kinova_binary_api_SOURCE_DIR}/include/client_stubs/ DESTINATION include/kortex_api)
+install(DIRECTORY ${kinova_binary_api_SOURCE_DIR}/include/google/protobuf DESTINATION include/kortex_api/google)
 
 ament_package()

--- a/kortex_driver/CMakeLists.txt
+++ b/kortex_driver/CMakeLists.txt
@@ -1,4 +1,12 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
+include(FetchContent)
+FetchContent_Declare(
+  kinova_binary_api
+  URL https://artifactory.kinovaapps.com:443/artifactory/generic-public/kortex/API/2.5.0/linux_x86-64_x86_gcc.zip
+  URL_HASH MD5=64bd86e7ab8bda90ef1fc7d6a356e080
+)
+FetchContent_MakeAvailable(kinova_binary_api)
+
 project(kortex_driver)
 
 # Default to C++14
@@ -20,6 +28,26 @@ find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(kortex_api REQUIRED)
 
+#Current: only support Linux x86_64
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  set(API_URL https://artifactory.kinovaapps.com:443/artifactory/generic-public/kortex/API/2.5.0/linux_x86-64_x86_gcc.zip)
+else()
+  # TODO(future) to support ARM or other builds logic could go here to fetch the precompiled libKortexApiCpp.a
+  # see notes in kortex_api CMakeList.txt
+  message(WARNING "Detected ${CMAKE_SYSTEM_NAME} and ${CMAKE_SYSTEM_PROCESSOR}")
+  message(FATAL_ERROR "Unsupported System: currently support is for Linux x68_64.")
+endif()
+
+# CMake does not allow IMPORTED libraries to be installed
+# The package kortex_api will download and setup the include directories
+add_library(KortexApiCpp STATIC IMPORTED)
+set_target_properties(KortexApiCpp PROPERTIES
+  IMPORTED_LOCATION ${kinova_binary_api_SOURCE_DIR}/lib/release/libKortexApiCpp.a
+  INTERFACE_LINK_LIBRARIES KortexApiCpp
+)
+target_link_libraries(KortexApiCpp INTERFACE pthread)
+add_dependencies(KortexApiCpp kortex_api)
+
 ## COMPILE
 add_library(
   ${PROJECT_NAME}
@@ -27,11 +55,13 @@ add_library(
   src/hardware_interface.cpp
   src/kortex_math_util.cpp
 )
+target_link_libraries(${PROJECT_NAME} KortexApiCpp)
 target_include_directories(
   ${PROJECT_NAME}
   PRIVATE
   include
 )
+# kortex_api is the headers for the Kortex API
 ament_target_dependencies(
   ${PROJECT_NAME}
   SYSTEM kortex_api

--- a/kortex_driver/include/kortex_driver/hardware_interface.hpp
+++ b/kortex_driver/include/kortex_driver/hardware_interface.hpp
@@ -43,12 +43,12 @@
 
 #include "kortex_driver/visibility_control.h"
 
-#include <BaseClientRpc.h>
-#include <BaseCyclicClientRpc.h>
-#include <RouterClient.h>
-#include <SessionManager.h>
-#include <TransportClientTcp.h>
-#include <TransportClientUdp.h>
+#include "BaseClientRpc.h"
+#include "BaseCyclicClientRpc.h"
+#include "RouterClient.h"
+#include "SessionManager.h"
+#include "TransportClientTcp.h"
+#include "TransportClientUdp.h"
 
 namespace hardware_interface
 {


### PR DESCRIPTION
This commit does several two main things:
1) kortex_api now only installs the header files and they now do not pollute include
2) kortex_driver gets the binary libKortexApiCpp.a itself

kortex_driver gets the headers from kortex_api this avoids protobuf errors because those header files and the libKortexApiCpp.a were generated using non-system protobuf

kortex_api cannot install the libKortexApiCpp.a because CMake does not allow installing library which was IMPORTED

This should fix the debian packages which are currently released