### PR TITLE
Specify MoveIt Planners to use

### DIFF
--- a/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
+++ b/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
@@ -52,7 +52,7 @@ def launch_setup(context, *args, **kwargs):
     moveit_config = (
         MoveItConfigsBuilder("gen3", package_name="kinova_gen3_6dof_robotiq_2f_85_moveit_config")
         .robot_description(mappings=launch_arguments)
-        .planning_pipelines(pipelines=["ompl"])
+        .planning_pipelines(pipelines=["ompl", "chomp", "pilz_industrial_motion_planner"])
         .to_moveit_configs()
     )
 

--- a/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
+++ b/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
@@ -57,6 +57,9 @@ def generate_launch_description():
     moveit_config = (
         MoveItConfigsBuilder("gen3", package_name="kinova_gen3_6dof_robotiq_2f_85_moveit_config")
         .robot_description(mappings=launch_arguments)
+        .planning_pipelines(
+            pipelines=["ompl", "chomp", "pilz_industrial_motion_planner"]
+        )
         .to_moveit_configs()
     )
 

--- a/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
+++ b/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
@@ -57,9 +57,7 @@ def generate_launch_description():
     moveit_config = (
         MoveItConfigsBuilder("gen3", package_name="kinova_gen3_6dof_robotiq_2f_85_moveit_config")
         .robot_description(mappings=launch_arguments)
-        .planning_pipelines(
-            pipelines=["ompl", "chomp", "pilz_industrial_motion_planner"]
-        )
+        .planning_pipelines(pipelines=["ompl", "chomp", "pilz_industrial_motion_planner"])
         .to_moveit_configs()
     )
 

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
@@ -77,6 +77,9 @@ def generate_launch_description():
     moveit_config = (
         MoveItConfigsBuilder("gen3", package_name="kinova_gen3_7dof_robotiq_2f_85_moveit_config")
         .robot_description(mappings=launch_arguments)
+        .planning_pipelines(
+            pipelines=["ompl", "chomp", "pilz_industrial_motion_planner"]
+        )
         .to_moveit_configs()
     )
 

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
@@ -52,7 +52,7 @@ def launch_setup(context, *args, **kwargs):
     moveit_config = (
         MoveItConfigsBuilder("gen3", package_name="kinova_gen3_7dof_robotiq_2f_85_moveit_config")
         .robot_description(mappings=launch_arguments)
-        .planning_pipelines(pipelines=["ompl"])
+        .planning_pipelines(pipelines=["ompl", "chomp", "pilz_industrial_motion_planner"])
         .to_moveit_configs()
     )
 

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
@@ -77,9 +77,7 @@ def generate_launch_description():
     moveit_config = (
         MoveItConfigsBuilder("gen3", package_name="kinova_gen3_7dof_robotiq_2f_85_moveit_config")
         .robot_description(mappings=launch_arguments)
-        .planning_pipelines(
-            pipelines=["ompl", "chomp", "pilz_industrial_motion_planner"]
-        )
+        .planning_pipelines(pipelines=["ompl", "chomp", "pilz_industrial_motion_planner"])
         .to_moveit_configs()
     )
 


### PR DESCRIPTION
Define MoveIt planners to use. This way, we can avoid trying to use Stomp in a version of ROS where it isn't available/released.