### PR TITLE
Depend on gz-ros2-control instead of gazebo-ros2-control

### DIFF
--- a/kortex_bringup/package.xml
+++ b/kortex_bringup/package.xml
@@ -22,7 +22,7 @@
   <exec_depend>rviz2</exec_depend>
   <exec_depend>urdf</exec_depend>
   <exec_depend>xacro</exec_depend>
-  <exec_depend>gazebo_ros2_control</exec_depend>
+  <exec_depend>gz_ros2_control</exec_depend>
   <exec_depend>gripper_controllers</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>

--- a/kortex_bringup/package.xml
+++ b/kortex_bringup/package.xml
@@ -22,7 +22,8 @@
   <exec_depend>rviz2</exec_depend>
   <exec_depend>urdf</exec_depend>
   <exec_depend>xacro</exec_depend>
-  <exec_depend>ign_ros2_control</exec_depend>
+  <exec_depend condition="$ROS_DISTRO == humble">ign_ros2_control</exec_depend>
+  <exec_depend condition="$ROS_DISTRO != humble">gz_ros2_control</exec_depend>
   <exec_depend>gripper_controllers</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>

--- a/kortex_bringup/package.xml
+++ b/kortex_bringup/package.xml
@@ -22,7 +22,7 @@
   <exec_depend>rviz2</exec_depend>
   <exec_depend>urdf</exec_depend>
   <exec_depend>xacro</exec_depend>
-  <exec_depend>gz_ros2_control</exec_depend>
+  <exec_depend>ign_ros2_control</exec_depend>
   <exec_depend>gripper_controllers</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>


### PR DESCRIPTION
We currently don't support Gazebo classic and have focused on support Ignition Gazebo so we should no longer depend on gazebo_ros2_control and instead depend on gz_ros2_control. 

This will benefit the user because gazebo-ros2-control and gz-ros2-control currently conflict with each other. 