### PR TITLE
[CI] ament_lint_cmake skip kortex_drivers

### DIFF
--- a/.github/workflows/ci-ros-lint.yml
+++ b/.github/workflows/ci-ros-lint.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          linter: [cppcheck, copyright, lint_cmake]
+          linter: [cppcheck, copyright]
     steps:
     - uses: actions/checkout@v3
     - uses: ros-tooling/setup-ros@v0.6
@@ -21,6 +21,23 @@ jobs:
           kortex_bringup
           kortex_driver
 
+  # ament_lint_cmake complains about [readability/wonkycase]
+  # but there is no argument to ignore the wonky case
+  # the pre-commit hook also skips kortex_driver and kortex_api
+  ament_lint_cmake:
+    name: ament_lint_cmake
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ros-tooling/setup-ros@v0.6
+    - uses: ros-tooling/action-ros-lint@v0.1
+      with:
+        distribution: rolling
+        linter: lint_cmake
+        package-name:
+          kortex_bringup
 
   ament_lint_100:
     name: ament_${{ matrix.linter }}


### PR DESCRIPTION
ament_lint_cmake fails due to to known readability/wonkycase
1. FetchContent_Declare
2. FetchContent_MakeAvailable

These mix CamelCase_And_Underscores

Error: kortex_driver/CMakeLists.txt:3: Do not use mixed case commands [readability/wonkycase]
Error: kortex_driver/CMakeLists.txt:8: Do not use mixed case commands [readability/wonkycase]

I couldn't find a way to disable this via an argument. This test is also skipped via ".pre-commit-config.yaml" on this directory