### PR TITLE
cxx: remove unused-but-set-parameter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,7 @@ repos:
         entry: env AMENT_CPPCHECK_ALLOW_SLOW_VERSIONS=1 ament_cppcheck
         language: system
         files: \.(h\+\+|h|hh|hxx|hpp|cuh|c|cc|cpp|cu|c\+\+|cxx|tpp|txx)$
-        exclude: kortex_api/
+        exclude: 'kortex_api/.*'
 
   # Maybe use https://github.com/cpplint/cpplint instead
   - repo: local
@@ -98,7 +98,8 @@ repos:
         language: system
         files: \.(h\+\+|h|hh|hxx|hpp|cuh|c|cc|cpp|cu|c\+\+|cxx|tpp|txx)$
         args: ["--linelength=100", "--filter=-whitespace/newline"]
-        exclude: kortex_api/
+        # https://github.com/cpplint/cpplint/issues/131 kortex_math_util false positive with unamed func parameter
+        exclude: 'kortex_api/.*|kortex_driver/src/kortex_math_util.cpp'
 
   # Cmake hooks
   - repo: local

--- a/kortex_driver/src/kortex_math_util.cpp
+++ b/kortex_driver/src/kortex_math_util.cpp
@@ -10,10 +10,9 @@ double KortexMathUtil::toRad(double degree) { return degree * M_PI / 180.0; }
 
 double KortexMathUtil::toDeg(double rad) { return rad * 180.0 / M_PI; }
 
-int KortexMathUtil::getNumberOfTurns(double rad_not_wrapped)
+int KortexMathUtil::getNumberOfTurns(double /*rad_not_wrapped*/)
 {
   // it is between
-  rad_not_wrapped = 0;
   return 0;
 }
 


### PR DESCRIPTION
- kortex_math_util.cpp originates from the original ros_kortex
- modifies pre-commit-config because cpplint has false readability/casting error

This kortex_math_util function comes from the ros_kortex repo and is actually unimplemented leaving it as is and ignoring the warning to keep ros2_kortex and ros_kortex similar