### PR TITLE
Update the README on `twist_controller` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ ros2 service call /controller_manager/switch_controller controller_manager_msgs/
 }"
 ```
 
+**Note: the required interface for the `twist_controller` does not currently exist in the gazebo or mock hardware simulation setups. So the `twist_controller` is currently only functional on Kinova hardware.**
+
 Once the `twist_controller` is activated, You can publish Twist messages on the `/twist_controller/commands` topic to command the arm.
 
 For example, you can jog the arm using [Teleop Twist Keyboard](https://index.ros.org/p/teleop_twist_keyboard/github-ros2-teleop_twist_keyboard/) with the following command:


### PR DESCRIPTION
The `twist_controller` does not currently work in simulation because the required interfaces are not mocked. Add a note in the README to this end.

Resolves #182