### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ If the bug fix you need isn't in a released version or If you want to build this
 
 4. To simulate the robot with ignition or gazebo make sure to pull and build additional packages:
    ```
-   vcs import src --skip-existing --input src/ros2_kortex/simulation.repos
+   vcs import src --skip-existing --input src/ros2_kortex/simulation.humble.repos
    rosdep install --ignore-src --from-paths src -y -r
    colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
    source install/setup.bash


### PR DESCRIPTION
changed Step 4 of install to import simulation.humble.repos instead of simulation.repos as the colcon build failed when using master branches of simulation.repos repositories