### PR TITLE
Update planning pipeline configurations

### DIFF
--- a/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/config/ompl_planning.yaml
+++ b/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/config/ompl_planning.yaml
@@ -3,9 +3,8 @@ start_state_max_bounds_error: 0.1
 jiggle_fraction: 0.05
 request_adapters:
   - default_planning_request_adapters/ResolveConstraintFrames
-  - default_planning_request_adapters/FixWorkspaceBounds
-  - default_planning_request_adapters/FixStartStateBounds
-  - default_planning_request_adapters/FixStartStateCollision
-  - default_planning_request_adapters/FixStartStatePathConstraints
+  - default_planning_request_adapters/CheckStartStateBounds
+  - default_planning_request_adapters/CheckStartStateCollision
+  - default_planning_request_adapters/ValidateWorkspaceBounds
 response_adapters:
   - default_planning_response_adapters/AddTimeOptimalParameterization

--- a/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/config/ompl_planning.yaml
+++ b/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/config/ompl_planning.yaml
@@ -2,9 +2,9 @@ planning_plugin: ompl_interface/OMPLPlanner
 start_state_max_bounds_error: 0.1
 jiggle_fraction: 0.05
 request_adapters:
-  - default_planner_request_adapters/ResolveConstraintFrames
-  - default_planner_request_adapters/FixWorkspaceBounds
-  - default_planner_request_adapters/FixStartStateBounds
-  - default_planner_request_adapters/FixStartStateCollision
+  - default_planning_request_adapters/ResolveConstraintFrames
+  - default_planning_request_adapters/FixWorkspaceBounds
+  - default_planning_request_adapters/FixStartStateBounds
+  - default_planning_request_adapters/FixStartStateCollision
 response_adapters:
-  - default_planner_response_adapters/AddTimeOptimalParameterization
+  - default_planning_response_adapters/AddTimeOptimalParameterization

--- a/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/config/ompl_planning.yaml
+++ b/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/config/ompl_planning.yaml
@@ -1,10 +1,10 @@
 planning_plugin: ompl_interface/OMPLPlanner
 start_state_max_bounds_error: 0.1
 jiggle_fraction: 0.05
-request_adapters: >-
-    default_planner_request_adapters/AddTimeOptimalParameterization
-    default_planner_request_adapters/ResolveConstraintFrames
-    default_planner_request_adapters/FixWorkspaceBounds
-    default_planner_request_adapters/FixStartStateBounds
-    default_planner_request_adapters/FixStartStateCollision
-    default_planner_request_adapters/FixStartStatePathConstraints
+request_adapters:
+  - default_planner_request_adapters/ResolveConstraintFrames
+  - default_planner_request_adapters/FixWorkspaceBounds
+  - default_planner_request_adapters/FixStartStateBounds
+  - default_planner_request_adapters/FixStartStateCollision
+response_adapters:
+  - default_planner_response_adapters/AddTimeOptimalParameterization

--- a/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/config/ompl_planning.yaml
+++ b/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/config/ompl_planning.yaml
@@ -6,5 +6,6 @@ request_adapters:
   - default_planning_request_adapters/FixWorkspaceBounds
   - default_planning_request_adapters/FixStartStateBounds
   - default_planning_request_adapters/FixStartStateCollision
+  - default_planning_request_adapters/FixStartStatePathConstraints
 response_adapters:
   - default_planning_response_adapters/AddTimeOptimalParameterization

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/config/ompl_planning.yaml
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/config/ompl_planning.yaml
@@ -3,9 +3,8 @@ start_state_max_bounds_error: 0.1
 jiggle_fraction: 0.05
 request_adapters:
   - default_planning_request_adapters/ResolveConstraintFrames
-  - default_planning_request_adapters/FixWorkspaceBounds
-  - default_planning_request_adapters/FixStartStateBounds
-  - default_planning_request_adapters/FixStartStateCollision
-  - default_planning_request_adapters/FixStartStatePathConstraints
+  - default_planning_request_adapters/CheckStartStateBounds
+  - default_planning_request_adapters/CheckStartStateCollision
+  - default_planning_request_adapters/ValidateWorkspaceBounds
 response_adapters:
-  - default_planner_response_adapters/AddTimeOptimalParameterization
+  - default_planning_response_adapters/AddTimeOptimalParameterization

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/config/ompl_planning.yaml
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/config/ompl_planning.yaml
@@ -6,5 +6,6 @@ request_adapters:
   - default_planning_request_adapters/FixWorkspaceBounds
   - default_planning_request_adapters/FixStartStateBounds
   - default_planning_request_adapters/FixStartStateCollision
+  - default_planning_request_adapters/FixStartStatePathConstraints
 response_adapters:
   - default_planner_response_adapters/AddTimeOptimalParameterization

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/config/ompl_planning.yaml
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/config/ompl_planning.yaml
@@ -1,10 +1,10 @@
 planning_plugin: ompl_interface/OMPLPlanner
 start_state_max_bounds_error: 0.1
 jiggle_fraction: 0.05
-request_adapters: >-
-    default_planner_request_adapters/AddTimeOptimalParameterization
-    default_planner_request_adapters/ResolveConstraintFrames
-    default_planner_request_adapters/FixWorkspaceBounds
-    default_planner_request_adapters/FixStartStateBounds
-    default_planner_request_adapters/FixStartStateCollision
-    default_planner_request_adapters/FixStartStatePathConstraints
+request_adapters:
+  - default_planner_request_adapters/ResolveConstraintFrames
+  - default_planner_request_adapters/FixWorkspaceBounds
+  - default_planner_request_adapters/FixStartStateBounds
+  - default_planner_request_adapters/FixStartStateCollision
+response_adapters:
+  - default_planner_response_adapters/AddTimeOptimalParameterization

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/config/ompl_planning.yaml
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/config/ompl_planning.yaml
@@ -2,9 +2,9 @@ planning_plugin: ompl_interface/OMPLPlanner
 start_state_max_bounds_error: 0.1
 jiggle_fraction: 0.05
 request_adapters:
-  - default_planner_request_adapters/ResolveConstraintFrames
-  - default_planner_request_adapters/FixWorkspaceBounds
-  - default_planner_request_adapters/FixStartStateBounds
-  - default_planner_request_adapters/FixStartStateCollision
+  - default_planning_request_adapters/ResolveConstraintFrames
+  - default_planning_request_adapters/FixWorkspaceBounds
+  - default_planning_request_adapters/FixStartStateBounds
+  - default_planning_request_adapters/FixStartStateCollision
 response_adapters:
   - default_planner_response_adapters/AddTimeOptimalParameterization


### PR DESCRIPTION
This PR contains updates needed for some MoveIt 2 refactors of planning pipeline adapter specifications in https://github.com/ros-planning/moveit2/pull/2429.