### PR TITLE
Fix mention of nonexistent STL file

### DIFF
--- a/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
+++ b/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
@@ -374,7 +374,7 @@
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="file://$(find kortex_description)/arms/gen3/${dof}dof/meshes/bracelet_with_vision_link.STL" />
+          <mesh filename="file://$(find kortex_description)/arms/gen3/${dof}dof/meshes/bracelet_with_vision_link.dae" />
         </geometry>
       </collision>
     </link>


### PR DESCRIPTION
The STL files were replaced with dae files, but one of the old STL files is pointed to in the gen3_macro.xacro file. Update it to point to the corresponding dae file.