### PR TITLE
fake_components -> mock_components

### DIFF
--- a/kortex_description/arms/gen3/6dof/urdf/kortex.ros2_control.xacro
+++ b/kortex_description/arms/gen3/6dof/urdf/kortex.ros2_control.xacro
@@ -39,7 +39,7 @@
           <param name="joint_states_topic">${isaac_joint_states}</param>
         </xacro:if>
         <xacro:if value="${use_fake_hardware}">
-          <plugin>fake_components/GenericSystem</plugin>
+          <plugin>mock_components/GenericSystem</plugin>
           <param name="fake_sensor_commands">${fake_sensor_commands}</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>

--- a/kortex_description/arms/gen3/7dof/urdf/kortex.ros2_control.xacro
+++ b/kortex_description/arms/gen3/7dof/urdf/kortex.ros2_control.xacro
@@ -39,7 +39,7 @@
           <param name="joint_states_topic">${isaac_joint_states}</param>
         </xacro:if>
         <xacro:if value="${use_fake_hardware}">
-          <plugin>fake_components/GenericSystem</plugin>
+          <plugin>mock_components/GenericSystem</plugin>
           <param name="fake_sensor_commands">${fake_sensor_commands}</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>

--- a/kortex_description/arms/gen3_lite/6dof/urdf/kortex.ros2_control.xacro
+++ b/kortex_description/arms/gen3_lite/6dof/urdf/kortex.ros2_control.xacro
@@ -39,7 +39,7 @@
           <param name="joint_states_topic">${isaac_joint_states}</param>
         </xacro:if>
         <xacro:if value="${use_fake_hardware}">
-          <plugin>fake_components/GenericSystem</plugin>
+          <plugin>mock_components/GenericSystem</plugin>
           <param name="fake_sensor_commands">${fake_sensor_commands}</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>


### PR DESCRIPTION
Resolves the segfault
```
terminate called after throwing an instance of 'pluginlib::LibraryLoadException'
[ros2_control_node-5]   what():  According to the loaded plugin descriptions the class fake_components/GenericSystem with base class type hardware_interface::SystemInterface does not exist. Declared types are  kortex_driver/KortexMultiInterfaceHardware mock_components/GenericSystem test_hardware_components/TestSystemCommandModes test_hardware_components/TestTwoJointSystem test_system
```