### PR TITLE
Update ros2_control usage to recent deprecations

### DIFF
--- a/kortex_bringup/launch/kortex_control.launch.py
+++ b/kortex_bringup/launch/kortex_control.launch.py
@@ -123,7 +123,10 @@ def launch_setup(context, *args, **kwargs):
     control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[robot_description, robot_controllers],
+        parameters=[robot_controllers],
+        remappings=[
+            ("/controller_manager/robot_description", "/robot_description"),
+        ],
         output="both",
     )
 

--- a/kortex_description/arms/gen3/6dof/urdf/kortex.ros2_control.xacro
+++ b/kortex_description/arms/gen3/6dof/urdf/kortex.ros2_control.xacro
@@ -158,8 +158,6 @@
           <state_interface name="velocity">
             <param name="initial_value">0.0</param>
           </state_interface>
-          <param name="initial_value">0.0</param>
-        </state_interface>
         </joint>
       </xacro:if>
     </ros2_control>

--- a/kortex_description/arms/gen3/6dof/urdf/kortex.ros2_control.xacro
+++ b/kortex_description/arms/gen3/6dof/urdf/kortex.ros2_control.xacro
@@ -67,8 +67,12 @@
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_1']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_2">
         <command_interface name="position">
@@ -78,8 +82,12 @@
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_2']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position">
@@ -89,8 +97,12 @@
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_3']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_4">
         <command_interface name="position">
@@ -100,8 +112,12 @@
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_4']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position">
@@ -111,8 +127,12 @@
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_5']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position">
@@ -122,14 +142,24 @@
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_6']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <xacro:if value="${use_internal_bus_gripper_comm}">
         <joint name="${prefix}${gripper_joint_name}">
-          <command_interface name="position" />
-          <state_interface name="position"/>
-          <state_interface name="velocity"/>
+          <command_interface name="position"/>
+          <state_interface name="position">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <state_interface name="velocity">
+            <param name="initial_value">0.0</param>
+          </state_interface>
+          <param name="initial_value">0.0</param>
+        </state_interface>
         </joint>
       </xacro:if>
     </ros2_control>

--- a/kortex_description/arms/gen3/7dof/urdf/kortex.ros2_control.xacro
+++ b/kortex_description/arms/gen3/7dof/urdf/kortex.ros2_control.xacro
@@ -67,8 +67,12 @@
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_1']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_2">
         <command_interface name="position">
@@ -78,8 +82,12 @@
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_2']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position">
@@ -89,8 +97,12 @@
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_3']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_4">
         <command_interface name="position">
@@ -100,8 +112,12 @@
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_4']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position">
@@ -111,8 +127,12 @@
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_5']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position">
@@ -122,8 +142,12 @@
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_6']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_7">
         <command_interface name="position">
@@ -133,15 +157,23 @@
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_7']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_ignition or sim_isaac}">
         <xacro:if value="${use_internal_bus_gripper_comm}">
           <joint name="${prefix}${gripper_joint_name}">
             <command_interface name="position" />
-            <state_interface name="position"/>
-            <state_interface name="velocity"/>
+            <state_interface name="position">
+              <param name="initial_value">0.0</param>
+            </state_interface>
+            <state_interface name="velocity">
+              <param name="initial_value">0.0</param>
+        </state_interface>
           </joint>
         </xacro:if>
       </xacro:unless>

--- a/kortex_description/arms/gen3_lite/6dof/urdf/kortex.ros2_control.xacro
+++ b/kortex_description/arms/gen3_lite/6dof/urdf/kortex.ros2_control.xacro
@@ -67,8 +67,12 @@
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_1']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_2">
         <command_interface name="position">
@@ -78,8 +82,12 @@
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_2']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position">
@@ -89,8 +97,12 @@
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_3']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_4">
         <command_interface name="position">
@@ -100,8 +112,12 @@
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_4']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position">
@@ -111,8 +127,12 @@
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_5']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position">
@@ -122,15 +142,23 @@
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_6']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_ignition or sim_isaac}">
         <xacro:if value="${use_internal_bus_gripper_comm}">
           <joint name="${prefix}right_finger_bottom_joint">
             <command_interface name="position"/>
-            <state_interface name="position"/>
-            <state_interface name="velocity"/>
+            <state_interface name="position">
+              <param name="initial_value">0.0</param>
+            </state_interface>
+            <state_interface name="velocity">
+              <param name="initial_value">0.0</param>
+            </state_interface>
           </joint>
         </xacro:if>
       </xacro:unless>

--- a/kortex_description/grippers/gen3_lite_2f/urdf/gen3_lite_2f.ros2_control.xacro
+++ b/kortex_description/grippers/gen3_lite_2f/urdf/gen3_lite_2f.ros2_control.xacro
@@ -36,7 +36,9 @@
                 <state_interface name="position">
                     <param name="initial_value">0.85</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                  <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <!-- When simulating we need to include the rest of the gripper joints -->
             <xacro:if value="${use_fake_hardware or sim_isaac or sim_ignition}">
@@ -45,8 +47,12 @@
                     <param name="multiplier">-1</param>
                     <xacro:unless value="${sim_ignition}">
                         <command_interface name="position"/>
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
+                        <state_interface name="position">
+                          <param name="initial_value">0.0</param>
+                        </state_interface>
+                        <state_interface name="velocity">
+                          <param name="initial_value">0.0</param>
+                        </state_interface>
                     </xacro:unless>
                 </joint>
                 <joint name="${prefix}left_finger_bottom_joint">
@@ -54,8 +60,12 @@
                     <param name="multiplier">1</param>
                     <xacro:unless value="${sim_ignition}">
                         <command_interface name="position"/>
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
+                        <state_interface name="position">
+                          <param name="initial_value">0.0</param>
+                        </state_interface>
+                        <state_interface name="velocity">
+                          <param name="initial_value">0.0</param>
+                        </state_interface>
                     </xacro:unless>
                 </joint>
                 <joint name="${prefix}left_finger_tip_joint">
@@ -63,8 +73,12 @@
                     <param name="multiplier">-1</param>
                     <xacro:unless value="${sim_ignition}">
                         <command_interface name="position"/>
-                        <state_interface name="position"/>
-                        <state_interface name="velocity"/>
+                        <state_interface name="position">
+                          <param name="initial_value">0.0</param>
+                        </state_interface>
+                        <state_interface name="velocity">
+                          <param name="initial_value">0.0</param>
+                        </state_interface>
                     </xacro:unless>
                 </joint>
             </xacro:if>

--- a/kortex_description/robots/gen3_2f85.urdf
+++ b/kortex_description/robots/gen3_2f85.urdf
@@ -38,8 +38,12 @@
       <state_interface name="position">
         <param name="initial_value">0.0</param>
       </state_interface>
-      <state_interface name="velocity"/>
-      <state_interface name="effort"/>
+      <state_interface name="velocity">
+        <param name="initial_value">0.0</param>
+      </state_interface>
+      <state_interface name="effort">
+        <param name="initial_value">0.0</param>
+      </state_interface>
     </joint>
     <joint name="gen3_joint_2">
       <command_interface name="position">
@@ -53,8 +57,12 @@
       <state_interface name="position">
         <param name="initial_value">0.0</param>
       </state_interface>
-      <state_interface name="velocity"/>
-      <state_interface name="effort"/>
+      <state_interface name="velocity">
+        <param name="initial_value">0.0</param>
+      </state_interface>
+      <state_interface name="effort">
+        <param name="initial_value">0.0</param>
+      </state_interface>
     </joint>
     <joint name="gen3_joint_3">
       <command_interface name="position">
@@ -68,8 +76,12 @@
       <state_interface name="position">
         <param name="initial_value">0.0</param>
       </state_interface>
-      <state_interface name="velocity"/>
-      <state_interface name="effort"/>
+      <state_interface name="velocity">
+        <param name="initial_value">0.0</param>
+      </state_interface>
+      <state_interface name="effort">
+        <param name="initial_value">0.0</param>
+      </state_interface>
     </joint>
     <joint name="gen3_joint_4">
       <command_interface name="position">
@@ -83,8 +95,12 @@
       <state_interface name="position">
         <param name="initial_value">0.0</param>
       </state_interface>
-      <state_interface name="velocity"/>
-      <state_interface name="effort"/>
+      <state_interface name="velocity">
+        <param name="initial_value">0.0</param>
+      </state_interface>
+      <state_interface name="effort">
+        <param name="initial_value">0.0</param>
+      </state_interface>
     </joint>
     <joint name="gen3_joint_5">
       <command_interface name="position">
@@ -98,8 +114,12 @@
       <state_interface name="position">
         <param name="initial_value">0.0</param>
       </state_interface>
-      <state_interface name="velocity"/>
-      <state_interface name="effort"/>
+      <state_interface name="velocity">
+        <param name="initial_value">0.0</param>
+      </state_interface>
+      <state_interface name="effort">
+        <param name="initial_value">0.0</param>
+      </state_interface>
     </joint>
     <joint name="gen3_joint_6">
       <command_interface name="position">
@@ -113,8 +133,12 @@
       <state_interface name="position">
         <param name="initial_value">0.0</param>
       </state_interface>
-      <state_interface name="velocity"/>
-      <state_interface name="effort"/>
+      <state_interface name="velocity">
+        <param name="initial_value">0.0</param>
+      </state_interface>
+      <state_interface name="effort">
+        <param name="initial_value">0.0</param>
+      </state_interface>
     </joint>
     <joint name="gen3_joint_7">
       <command_interface name="position">
@@ -128,8 +152,12 @@
       <state_interface name="position">
         <param name="initial_value">0.0</param>
       </state_interface>
-      <state_interface name="velocity"/>
-      <state_interface name="effort"/>
+      <state_interface name="velocity">
+        <param name="initial_value">0.0</param>
+      </state_interface>
+      <state_interface name="effort">
+        <param name="initial_value">0.0</param>
+      </state_interface>
     </joint>
   </ros2_control>
   <joint name="gen3_base_joint" type="fixed">

--- a/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
+++ b/kortex_moveit_config/kinova_gen3_6dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
@@ -96,7 +96,10 @@ def launch_setup(context, *args, **kwargs):
     ros2_control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[moveit_config.to_dict(), ros2_controllers_path],
+        parameters=[ros2_controllers_path],
+        remappings=[
+            ("/controller_manager/robot_description", "/robot_description"),
+        ],
         output="both",
     )
 

--- a/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
+++ b/kortex_moveit_config/kinova_gen3_7dof_robotiq_2f_85_moveit_config/launch/robot.launch.py
@@ -96,7 +96,10 @@ def launch_setup(context, *args, **kwargs):
     ros2_control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[moveit_config.to_dict(), ros2_controllers_path],
+        parameters=[ros2_controllers_path],
+        remappings=[
+            ("/controller_manager/robot_description", "/robot_description"),
+        ],
         output="both",
     )
 


### PR DESCRIPTION
Addresses [this deprecation warnings](https://github.com/ros-controls/ros2_control/blob/89c8658a3419e4d23aea37eda7b17a0d1eecb840/controller_manager/src/controller_manager.cpp#L276)

```
[Deprecated] Passing the robot description parameter directly to the control_manager node is deprecated. Use '~/robot_description' topic from 'robot_state_publisher' instead.
```
and [this deprecation warning](https://github.com/ros-controls/ros2_control/commit/0863acd6905af0eba4db1074f11edd60215758d5#diff-1d9f9ba7c75ec81444e8ed7da3e5ac7a9fac2c515cb752ccd45d7a520dff97b4)(removed in most recent release because it was so old):

```
Parsing of optional initial interface values failed or uses a deprecated format. Add initial values for every state interface in the ros2_control.xacro. For example:
[ros2_control_node-5] <state_interface name="velocity">
[ros2_control_node-5]   <param name="initial_value">0.0</param>
[ros2_control_node-5] </state_interface>
```