### PR TITLE
Update gripper descriptions for use on HW

### DIFF
--- a/kortex_description/grippers/robotiq_2f_140/urdf/robotiq_2f_140_macro.xacro
+++ b/kortex_description/grippers/robotiq_2f_140/urdf/robotiq_2f_140_macro.xacro
@@ -9,9 +9,15 @@
     sim_isaac:=false
     isaac_joint_commands:=/isaac_joint_commands
     isaac_joint_states:=/isaac_joint_states
-    include_ros2_control:=true
+    use_internal_bus_gripper_comm:=false
     com_port:=/dev/ttyUSB0">
     <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_140_macro.urdf.xacro" />
+
+    <!-- Hardware talks directly to the gripper so we don't need ros2_control unless we are simulating -->
+    <xacro:property name="include_ros2_control" value="false"/>
+    <xacro:if value="${sim_ignition or sim_isaac or use_fake_hardware or not use_internal_bus_gripper_comm}">
+      <xacro:property name="include_ros2_control" value="true"/>
+    </xacro:if>
 
     <xacro:robotiq_gripper
         name="RobotiqGripperHardwareInterface"

--- a/kortex_description/grippers/robotiq_2f_140/urdf/robotiq_2f_140_macro.xacro
+++ b/kortex_description/grippers/robotiq_2f_140/urdf/robotiq_2f_140_macro.xacro
@@ -9,7 +9,6 @@
     sim_isaac:=false
     isaac_joint_commands:=/isaac_joint_commands
     isaac_joint_states:=/isaac_joint_states
-    use_internal_bus_gripper_comm:=false
     include_ros2_control:=true
     com_port:=/dev/ttyUSB0">
     <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_140_macro.urdf.xacro" />

--- a/kortex_description/grippers/robotiq_2f_140/urdf/robotiq_2f_140_macro.xacro
+++ b/kortex_description/grippers/robotiq_2f_140/urdf/robotiq_2f_140_macro.xacro
@@ -9,19 +9,17 @@
     sim_isaac:=false
     isaac_joint_commands:=/isaac_joint_commands
     isaac_joint_states:=/isaac_joint_states
-    use_internal_bus_gripper_comm:=false">
+    use_internal_bus_gripper_comm:=false
+    include_ros2_control:=true
+    com_port:=/dev/ttyUSB0">
     <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_140_macro.urdf.xacro" />
 
-    <!-- Hardware talks directly to the gripper so we don't need ros2_control unless we are simulating -->
-    <xacro:property name="include_ros2_control" value="false"/>
-    <xacro:if value="${sim_ignition or sim_isaac or use_fake_hardware}">
-      <xacro:property name="include_ros2_control" value="true"/>
-    </xacro:if>
     <xacro:robotiq_gripper
         name="RobotiqGripperHardwareInterface"
         prefix="${prefix}"
         parent="${parent}"
         include_ros2_control="${include_ros2_control}"
+        com_port="${com_port}"
         use_fake_hardware="${use_fake_hardware}"
         fake_sensor_commands="${fake_sensor_commands}"
         sim_ignition="${sim_ignition}"

--- a/kortex_description/grippers/robotiq_2f_85/urdf/robotiq_2f_85_macro.xacro
+++ b/kortex_description/grippers/robotiq_2f_85/urdf/robotiq_2f_85_macro.xacro
@@ -9,19 +9,17 @@
     sim_isaac:=false
     isaac_joint_commands:=/isaac_joint_commands
     isaac_joint_states:=/isaac_joint_states
-    use_internal_bus_gripper_comm:=false">
+    use_internal_bus_gripper_comm:=false
+    include_ros2_control:=true
+    com_port:=/dev/ttyUSB0">
     <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_85_macro.urdf.xacro" />
 
-    <!-- Hardware talks directly to the gripper so we don't need ros2_control unless we are simulating -->
-    <xacro:property name="include_ros2_control" value="false"/>
-    <xacro:if value="${sim_ignition or sim_isaac or use_fake_hardware}">
-      <xacro:property name="include_ros2_control" value="true"/>
-    </xacro:if>
     <xacro:robotiq_gripper
         name="RobotiqGripperHardwareInterface"
         prefix="${prefix}"
         parent="${parent}"
         include_ros2_control="${include_ros2_control}"
+        com_port="${com_port}"
         use_fake_hardware="${use_fake_hardware}"
         fake_sensor_commands="${fake_sensor_commands}"
         sim_ignition="${sim_ignition}"

--- a/kortex_description/grippers/robotiq_2f_85/urdf/robotiq_2f_85_macro.xacro
+++ b/kortex_description/grippers/robotiq_2f_85/urdf/robotiq_2f_85_macro.xacro
@@ -9,7 +9,6 @@
     sim_isaac:=false
     isaac_joint_commands:=/isaac_joint_commands
     isaac_joint_states:=/isaac_joint_states
-    use_internal_bus_gripper_comm:=false
     include_ros2_control:=true
     com_port:=/dev/ttyUSB0">
     <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_85_macro.urdf.xacro" />

--- a/kortex_description/grippers/robotiq_2f_85/urdf/robotiq_2f_85_macro.xacro
+++ b/kortex_description/grippers/robotiq_2f_85/urdf/robotiq_2f_85_macro.xacro
@@ -9,9 +9,15 @@
     sim_isaac:=false
     isaac_joint_commands:=/isaac_joint_commands
     isaac_joint_states:=/isaac_joint_states
-    include_ros2_control:=true
+    use_internal_bus_gripper_comm:=false
     com_port:=/dev/ttyUSB0">
     <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_85_macro.urdf.xacro" />
+
+    <!-- Hardware talks directly to the gripper so we don't need ros2_control unless we are simulating -->
+    <xacro:property name="include_ros2_control" value="false"/>
+    <xacro:if value="${sim_ignition or sim_isaac or use_fake_hardware or not use_internal_bus_gripper_comm}">
+      <xacro:property name="include_ros2_control" value="true"/>
+    </xacro:if>
 
     <xacro:robotiq_gripper
         name="RobotiqGripperHardwareInterface"

--- a/kortex_description/readme.md
+++ b/kortex_description/readme.md
@@ -52,7 +52,7 @@ Param | Description | Default |
 `port_realtime` | Realtime port for Kortex hardware driver | - |
 `session_inactivity_timeout_ms` | The duration after which the robot will clean the client session if the client hangs up the connection brutally (should not happen with the ROS driver). | - |
 `connection_inactivity_timeout_ms` | The duration after which a connection is destroyed by the robot if no communication is detected between the client and the robot. | - |
-`use_internal_bus_gripper_comm` | Boolean value to indicate if your gripper will be communicated with through the internal Kinova communication interface. | false |
+`use_internal_bus_gripper_comm` | Boolean value to indicate if your gripper will be communicated with through the internal Kinova communication interface. Set to true if the gripper is directly plugged into the kinova arm. Set to false if running in simulation or if gripper is connected to PC via USB. Setting to false will create a ros2_control instance for the gripper. | false |
 `use_fake_hardware` | Boolean value to indicate whether or not the hardware components will be mocked. If true the hardware params will be ignored and the hardware components will be mocked. | false |
 `fake_sensor_commands` | Boolean value. If set to true will create fake command interfaces for faking sensor measurements with an external command. | false |
 `sim_gazebo` | Boolean value to indicate whether or not the gazebo_ros2_control/GazeboSystem plugin will be loaded. | false |
@@ -64,8 +64,7 @@ Param | Description | Default |
 `initial_positions` | Dictionary of initial joint positions. | {joint_1: 0.0, joint_2: 0.0, joint_3: 0.0, joint_4: 0.0, joint_5: 0.0, joint_6: 0.0, joint_7: 0.0} |
 `gripper_max_velocity` | Desired velocity in percentage (0.0-100.0%) with which the position will be set. | 100.0 |
 `gripper_max_force` | Desired force in percentage (0.0-100.0%) with which the position will be set. NOTE: deprecated according to the [Kortex repo](https://github.com/Kinovarobotics/kortex/blob/master/api_cpp/doc/markdown/messages/GripperCyclic/MotorCommand.md). | 100.0 |
-`gripper_include_ros2_control` | Boolean value that will launch a ros2_controller instance for the gripper if true. Should be set to true if communicating directly to the gripper from the PC running ROS via USB or if running in simulation. | true |
-`gripper_com_port` | Specifies the USB port that the gripper is plugged in on. | /dev/ttyUSB0 |
+`gripper_com_port` | Specifies the USB port that the gripper is plugged in on. This will only be used if `use_internal_bus_gripper_comm` is false. | /dev/ttyUSB0 |
 
 ### Example Usage
 #### Kinova gen3 with robotiq_2f_85 end effector connected via the internal Kinova communication interface
@@ -96,7 +95,6 @@ Param | Description | Default |
     initial_positions="${initial_positions}"
     use_external_cable="true"
     fake_sensor_commands="false"
-    gripper_include_ros2_control="false"
     gripper_com_port="">
     <origin xyz="0 0 0.0" rpy="0 0 0" />
   </xacro:load_robot>

--- a/kortex_description/readme.md
+++ b/kortex_description/readme.md
@@ -31,3 +31,37 @@ For example:
 ## Tool frame
 
 The `tool_frame` link refers to the tool frame used by the arm when it reports end effector position feedback.
+
+## Xacro Parameters for `load_robot` macro
+
+Param | Description | Example Value |
+:--- | :--------- | :------------------- |
+`parent` | Parent link in the URDF the arm should be attached to | `parent="world"` |
+`origin` | Origin of the robot relative to the specified parent link | `<origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />`|
+`prefix` | This is an optional prefix for all joint and link names in the kortex_description. It is used to allow differentiating between different arms in the same URDF. | `prefix=""`|
+`arm` | Name of your robot arm model. | `arm="gen3"` or `arm="gen3_lite"` |
+`gripper` | Name of gripper type | `gripper="robotiq_2f_85"` or `gripper="robotiq_2f_140"` |
+`gripper_joint_name` | Name of gripper joint to be actuated | `gripper_joint_name="robotiq_85_left_knuckle_joint" or gripper_joint_name="finger_joint"` |
+`dof` | Number of DOFs of your robot. | `dof="7"` or `dof="6"`|
+`vision` | Boolean value to indicate if your arm has a Vision Module. This argument only affects the visual representation of the arm in RViz. | `vision="true"` or `vision="false"` |
+`robot_ip` | The IP address of the robot you're connection to. | `robot_ip="192.168.1.10"` |
+`username` | The username for the robot connection. | `username="admin"` |
+`password` | The password for the robot connection. | `password="admin"` |
+`port` | Port for Kortex hardware driver | `port="10000"` |
+`port_realtime` | Realtime port for Kortex hardware driver | `port_realtime="10001"` |
+`session_inactivity_timeout_ms` | The duration after which the robot will clean the client session if the client hangs up the connection brutally (should not happen with the ROS driver). | `session_inactivity_timeout_ms="60000"` |
+`connection_inactivity_timeout_ms` | The duration after which a connection is destroyed by the robot if no communication is detected between the client and the robot. | `connection_inactivity_timeout_ms="2000"` |
+`use_internal_bus_gripper_comm` | Boolean value to indicate if your gripper will be communicated with through the internal Kinova communication interface. The default value is **false**. | `use_internal_bus_gripper_comm="false"` |
+`use_fake_hardware` | Boolean value to indicate whether or not the hardware components will be mocked. If true the hardware params will be ignored and the hardware components will be mocked. Defaults to **false** | `use_fake_hardware="false"` |
+`fake_sensor_commands` | Boolean value. If set to true will create fake command interfaces for faking sensor measurements with an external command. Defaults to **false**. | `fake_sensor_commands="false"` |
+`sim_gazebo` | Boolean value to indicate whether or not the gazebo_ros2_control/GazeboSystem plugin will be loaded. Defaults to **false**. | `sim_gazebo="false"` |
+`sim_ignition` | Boolean value to indicate whether or not the ign_ros2_control/IgnitionSystem plugin will be loaded. Defaults to **false**. | `sim_ignition="false"` |
+`sim_isaac` | Boolean value to indicate whether or not the topic_based_ros2_control/TopicBasedSystem plugin will be loaded and the "joint_commands_topic" and "joint_states_topic" parameters will be set to the `isaac_joint_commands` and `isaac_joint_states` values respectively. Defaults to **false**. | `sim_isaac="false"` |
+`isaac_joint_commands` | Name of the joint commands topic to be used by Isaac Sim. Defaults to **/isaac_joint_commands**. | `isaac_joint_commands="/isaac_joint_commands"` |
+`isaac_joint_states` | Name of the joint states topic to be used by Isaac Sim. Defaults to **/isaac_joint_states**. | `isaac_joint_states="/isaac_joint_states"` |
+`use_external_cable` | Boolean value that sets joint limits to avoid wrapping of external cables if true. Defaults to **false**. | `use_external_cable="false"` |
+`initial_positions` | Dictionary of initial joint positions. Defaults to `{joint_1: 0.0, joint_2: 0.0, joint_3: 0.0, joint_4: 0.0, joint_5: 0.0, joint_6: 0.0, joint_7: 0.0}`. | `initial_positions="${dict(joint_1=0.0,joint_2=0.0,joint_3=0.0,joint_4=0.0,joint_5=0.0,joint_6=0.0,joint_7=0.0)}"` |
+`gripper_max_velocity` | Desired velocity in percentage (0.0-100.0%) with which the position will be set. Defaults to **100.0**. | `gripper_max_velocity="100.0"`|
+`gripper_max_force` | Desired force in percentage (0.0-100.0%) with which the position will be set. Defaults to **100.0**. NOTE: deprecated according to the [Kortex repo](https://github.com/Kinovarobotics/kortex/blob/master/api_cpp/doc/markdown/messages/GripperCyclic/MotorCommand.md). | `gripper_max_force="100.0"`|
+`gripper_include_ros2_control` | Boolean value that will launch a ros2_controller instance for the gripper if true. Defaults to **true**. Should be set to true if communicating directly to the gripper from the PC running ROS via USB or if running in simulation. | `gripper_include_ros2_control="true"` |
+`gripper_com_port` | Specifies the USB port that the gripper is plugged in on. Defaults to **/dev/ttyUSB0**. | `gripper_com_port="/dev/ttyUSB0"` |

--- a/kortex_description/readme.md
+++ b/kortex_description/readme.md
@@ -34,34 +34,72 @@ The `tool_frame` link refers to the tool frame used by the arm when it reports e
 
 ## Xacro Parameters for `load_robot` macro
 
-Param | Description | Example Value |
-:--- | :--------- | :------------------- |
-`parent` | Parent link in the URDF the arm should be attached to | `parent="world"` |
-`origin` | Origin of the robot relative to the specified parent link | `<origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />`|
-`prefix` | This is an optional prefix for all joint and link names in the kortex_description. It is used to allow differentiating between different arms in the same URDF. | `prefix=""`|
-`arm` | Name of your robot arm model. | `arm="gen3"` or `arm="gen3_lite"` |
-`gripper` | Name of gripper type | `gripper="robotiq_2f_85"` or `gripper="robotiq_2f_140"` |
-`gripper_joint_name` | Name of gripper joint to be actuated | `gripper_joint_name="robotiq_85_left_knuckle_joint" or gripper_joint_name="finger_joint"` |
-`dof` | Number of DOFs of your robot. | `dof="7"` or `dof="6"`|
-`vision` | Boolean value to indicate if your arm has a Vision Module. This argument only affects the visual representation of the arm in RViz. | `vision="true"` or `vision="false"` |
-`robot_ip` | The IP address of the robot you're connection to. | `robot_ip="192.168.1.10"` |
-`username` | The username for the robot connection. | `username="admin"` |
-`password` | The password for the robot connection. | `password="admin"` |
-`port` | Port for Kortex hardware driver | `port="10000"` |
-`port_realtime` | Realtime port for Kortex hardware driver | `port_realtime="10001"` |
-`session_inactivity_timeout_ms` | The duration after which the robot will clean the client session if the client hangs up the connection brutally (should not happen with the ROS driver). | `session_inactivity_timeout_ms="60000"` |
-`connection_inactivity_timeout_ms` | The duration after which a connection is destroyed by the robot if no communication is detected between the client and the robot. | `connection_inactivity_timeout_ms="2000"` |
-`use_internal_bus_gripper_comm` | Boolean value to indicate if your gripper will be communicated with through the internal Kinova communication interface. The default value is **false**. | `use_internal_bus_gripper_comm="false"` |
-`use_fake_hardware` | Boolean value to indicate whether or not the hardware components will be mocked. If true the hardware params will be ignored and the hardware components will be mocked. Defaults to **false** | `use_fake_hardware="false"` |
-`fake_sensor_commands` | Boolean value. If set to true will create fake command interfaces for faking sensor measurements with an external command. Defaults to **false**. | `fake_sensor_commands="false"` |
-`sim_gazebo` | Boolean value to indicate whether or not the gazebo_ros2_control/GazeboSystem plugin will be loaded. Defaults to **false**. | `sim_gazebo="false"` |
-`sim_ignition` | Boolean value to indicate whether or not the ign_ros2_control/IgnitionSystem plugin will be loaded. Defaults to **false**. | `sim_ignition="false"` |
-`sim_isaac` | Boolean value to indicate whether or not the topic_based_ros2_control/TopicBasedSystem plugin will be loaded and the "joint_commands_topic" and "joint_states_topic" parameters will be set to the `isaac_joint_commands` and `isaac_joint_states` values respectively. Defaults to **false**. | `sim_isaac="false"` |
-`isaac_joint_commands` | Name of the joint commands topic to be used by Isaac Sim. Defaults to **/isaac_joint_commands**. | `isaac_joint_commands="/isaac_joint_commands"` |
-`isaac_joint_states` | Name of the joint states topic to be used by Isaac Sim. Defaults to **/isaac_joint_states**. | `isaac_joint_states="/isaac_joint_states"` |
-`use_external_cable` | Boolean value that sets joint limits to avoid wrapping of external cables if true. Defaults to **false**. | `use_external_cable="false"` |
-`initial_positions` | Dictionary of initial joint positions. Defaults to `{joint_1: 0.0, joint_2: 0.0, joint_3: 0.0, joint_4: 0.0, joint_5: 0.0, joint_6: 0.0, joint_7: 0.0}`. | `initial_positions="${dict(joint_1=0.0,joint_2=0.0,joint_3=0.0,joint_4=0.0,joint_5=0.0,joint_6=0.0,joint_7=0.0)}"` |
-`gripper_max_velocity` | Desired velocity in percentage (0.0-100.0%) with which the position will be set. Defaults to **100.0**. | `gripper_max_velocity="100.0"`|
-`gripper_max_force` | Desired force in percentage (0.0-100.0%) with which the position will be set. Defaults to **100.0**. NOTE: deprecated according to the [Kortex repo](https://github.com/Kinovarobotics/kortex/blob/master/api_cpp/doc/markdown/messages/GripperCyclic/MotorCommand.md). | `gripper_max_force="100.0"`|
-`gripper_include_ros2_control` | Boolean value that will launch a ros2_controller instance for the gripper if true. Defaults to **true**. Should be set to true if communicating directly to the gripper from the PC running ROS via USB or if running in simulation. | `gripper_include_ros2_control="true"` |
-`gripper_com_port` | Specifies the USB port that the gripper is plugged in on. Defaults to **/dev/ttyUSB0**. | `gripper_com_port="/dev/ttyUSB0"` |
+### Parameter Table
+Param | Description | Default |
+:---- | :---------- | :------ |
+`parent` | Parent link in the URDF the arm should be attached to | - |
+`origin` | Origin of the robot relative to the specified parent link | - |
+`prefix` | This is an optional prefix for all joint and link names in the kortex_description. It is used to allow differentiating between different arms in the same URDF. | - |
+`arm` | Name of your robot arm model. | - |
+`gripper` | Name of gripper type | - |
+`gripper_joint_name` | Name of gripper joint to be actuated | - |
+`dof` | Number of DOFs of your robot. | - |
+`vision` | Boolean value to indicate if your arm has a Vision Module. This argument only affects the visual representation of the arm in RViz. | - |
+`robot_ip` | The IP address of the robot you're connection to. | - |
+`username` | The username for the robot connection. | - |
+`password` | The password for the robot connection. | - |
+`port` | Port for Kortex hardware driver | - |
+`port_realtime` | Realtime port for Kortex hardware driver | - |
+`session_inactivity_timeout_ms` | The duration after which the robot will clean the client session if the client hangs up the connection brutally (should not happen with the ROS driver). | - |
+`connection_inactivity_timeout_ms` | The duration after which a connection is destroyed by the robot if no communication is detected between the client and the robot. | - |
+`use_internal_bus_gripper_comm` | Boolean value to indicate if your gripper will be communicated with through the internal Kinova communication interface. | false |
+`use_fake_hardware` | Boolean value to indicate whether or not the hardware components will be mocked. If true the hardware params will be ignored and the hardware components will be mocked. | false |
+`fake_sensor_commands` | Boolean value. If set to true will create fake command interfaces for faking sensor measurements with an external command. | false |
+`sim_gazebo` | Boolean value to indicate whether or not the gazebo_ros2_control/GazeboSystem plugin will be loaded. | false |
+`sim_ignition` | Boolean value to indicate whether or not the ign_ros2_control/IgnitionSystem plugin will be loaded. | false |
+`sim_isaac` | Boolean value to indicate whether or not the topic_based_ros2_control/TopicBasedSystem plugin will be loaded and the "joint_commands_topic" and "joint_states_topic" parameters will be set to the `isaac_joint_commands` and `isaac_joint_states` values respectively. | false |
+`isaac_joint_commands` | Name of the joint commands topic to be used by Isaac Sim. | /isaac_joint_commands |
+`isaac_joint_states` | Name of the joint states topic to be used by Isaac Sim. | /isaac_joint_states |
+`use_external_cable` | Boolean value that sets joint limits to avoid wrapping of external cables if true. | false |
+`initial_positions` | Dictionary of initial joint positions. | {joint_1: 0.0, joint_2: 0.0, joint_3: 0.0, joint_4: 0.0, joint_5: 0.0, joint_6: 0.0, joint_7: 0.0} |
+`gripper_max_velocity` | Desired velocity in percentage (0.0-100.0%) with which the position will be set. | 100.0 |
+`gripper_max_force` | Desired force in percentage (0.0-100.0%) with which the position will be set. NOTE: deprecated according to the [Kortex repo](https://github.com/Kinovarobotics/kortex/blob/master/api_cpp/doc/markdown/messages/GripperCyclic/MotorCommand.md). | 100.0 |
+`gripper_include_ros2_control` | Boolean value that will launch a ros2_controller instance for the gripper if true. Should be set to true if communicating directly to the gripper from the PC running ROS via USB or if running in simulation. | true |
+`gripper_com_port` | Specifies the USB port that the gripper is plugged in on. | /dev/ttyUSB0 |
+
+### Example Usage
+#### Kinova gen3 with robotiq_2f_85 end effector connected via the internal Kinova communication interface
+```
+<robot ...>
+...
+  <xacro:property name="initial_positions" value="${dict(joint_1=0.0, joint_2=0.0, joint_3=-3.14, joint_4=-2.51, joint_5=0.0, joint_6=0.96, joint_7=1.57)}"/>
+  <xacro:load_robot
+    parent="world"
+    arm="gen3"
+    gripper="robotiq_2f_85"
+    gripper_joint_name="robotiq_85_left_knuckle_joint"
+    dof="7"
+    vision="true"
+    robot_ip="192.168.1.10"
+    username="admin"
+    password="admin"
+    port="10000"
+    port_realtime="10001"
+    session_inactivity_timeout_ms="60000"
+    connection_inactivity_timeout_ms="2000"
+    use_internal_bus_gripper_comm="true"
+    sim_gazebo="false"
+    sim_ignition="false"
+    sim_isaac="false"
+    prefix=""
+    use_fake_hardware="false"
+    initial_positions="${initial_positions}"
+    use_external_cable="true"
+    fake_sensor_commands="false"
+    gripper_include_ros2_control="false"
+    gripper_com_port="">
+    <origin xyz="0 0 0.0" rpy="0 0 0" />
+  </xacro:load_robot>
+...
+</robot>
+```

--- a/kortex_description/robots/gen3_robotiq_2f_140.xacro
+++ b/kortex_description/robots/gen3_robotiq_2f_140.xacro
@@ -8,11 +8,24 @@
     <xacro:arg name="vision" default="true" />
 
     <xacro:arg name="gripper" default="robotiq_2f_140" />
+    <xacro:arg name="use_internal_bus_gripper_comm" default="false" />
+    <xacro:arg name="gripper_include_ros2_control" default="true" />
+    <xacro:arg name="gripper_com_port" default="/dev/ttyUSB0" />
 
     <xacro:arg name="sim" default="false" />
     <xacro:arg name="prefix" default="" />
 
     <xacro:include filename="$(find kortex_description)/robots/kortex_robot.xacro" />
-    <xacro:load_robot arm="$(arg arm)" gripper="$(arg gripper)" dof="$(arg dof)" vision="$(arg vision)" sim="$(arg sim)" prefix="$(arg prefix)"/>
+    <xacro:load_robot
+      arm="$(arg arm)"
+      gripper="$(arg gripper)"
+      dof="$(arg dof)"
+      vision="$(arg vision)"
+      sim="$(arg sim)"
+      prefix="$(arg prefix)"
+      use_internal_bus_gripper_comm="$(arg use_internal_bus_gripper_comm)"
+      gripper_include_ros2_control="$(arg gripper_include_ros2_control)"
+      gripper_com_port="$(arg gripper_com_port)">
+    </xacro:robotiq_gripper>
 
 </robot>

--- a/kortex_description/robots/gen3_robotiq_2f_140.xacro
+++ b/kortex_description/robots/gen3_robotiq_2f_140.xacro
@@ -9,7 +9,6 @@
 
     <xacro:arg name="gripper" default="robotiq_2f_140" />
     <xacro:arg name="use_internal_bus_gripper_comm" default="false" />
-    <xacro:arg name="gripper_include_ros2_control" default="true" />
     <xacro:arg name="gripper_com_port" default="/dev/ttyUSB0" />
 
     <xacro:arg name="sim" default="false" />
@@ -24,7 +23,6 @@
       sim="$(arg sim)"
       prefix="$(arg prefix)"
       use_internal_bus_gripper_comm="$(arg use_internal_bus_gripper_comm)"
-      gripper_include_ros2_control="$(arg gripper_include_ros2_control)"
       gripper_com_port="$(arg gripper_com_port)">
     </xacro:load_robot>
 

--- a/kortex_description/robots/gen3_robotiq_2f_140.xacro
+++ b/kortex_description/robots/gen3_robotiq_2f_140.xacro
@@ -26,6 +26,6 @@
       use_internal_bus_gripper_comm="$(arg use_internal_bus_gripper_comm)"
       gripper_include_ros2_control="$(arg gripper_include_ros2_control)"
       gripper_com_port="$(arg gripper_com_port)">
-    </xacro:robotiq_gripper>
+    </xacro:load_robot>
 
 </robot>

--- a/kortex_description/robots/gen3_robotiq_2f_85.xacro
+++ b/kortex_description/robots/gen3_robotiq_2f_85.xacro
@@ -8,11 +8,24 @@
     <xacro:arg name="vision" default="true" />
 
     <xacro:arg name="gripper" default="robotiq_2f_85" />
+    <xacro:arg name="use_internal_bus_gripper_comm" default="false" />
+    <xacro:arg name="gripper_include_ros2_control" default="true" />
+    <xacro:arg name="gripper_com_port" default="/dev/ttyUSB0" />
 
     <xacro:arg name="sim" default="false" />
     <xacro:arg name="prefix" default="" />
 
     <xacro:include filename="$(find kortex_description)/robots/kortex_robot.xacro" />
-    <xacro:load_robot arm="$(arg arm)" gripper="$(arg gripper)" dof="$(arg dof)" vision="$(arg vision)" sim="$(arg sim)" prefix="$(arg prefix)" />
+    <xacro:load_robot
+      arm="$(arg arm)"
+      gripper="$(arg gripper)"
+      dof="$(arg dof)"
+      vision="$(arg vision)"
+      sim="$(arg sim)"
+      prefix="$(arg prefix)"
+      use_internal_bus_gripper_comm="$(arg use_internal_bus_gripper_comm)"
+      gripper_include_ros2_control="$(arg gripper_include_ros2_control)"
+      gripper_com_port="$(arg gripper_com_port)">
+    </xacro:robotiq_gripper>
 
 </robot>

--- a/kortex_description/robots/gen3_robotiq_2f_85.xacro
+++ b/kortex_description/robots/gen3_robotiq_2f_85.xacro
@@ -9,7 +9,6 @@
 
     <xacro:arg name="gripper" default="robotiq_2f_85" />
     <xacro:arg name="use_internal_bus_gripper_comm" default="false" />
-    <xacro:arg name="gripper_include_ros2_control" default="true" />
     <xacro:arg name="gripper_com_port" default="/dev/ttyUSB0" />
 
     <xacro:arg name="sim" default="false" />
@@ -24,7 +23,6 @@
       sim="$(arg sim)"
       prefix="$(arg prefix)"
       use_internal_bus_gripper_comm="$(arg use_internal_bus_gripper_comm)"
-      gripper_include_ros2_control="$(arg gripper_include_ros2_control)"
       gripper_com_port="$(arg gripper_com_port)">
     </xacro:load_robot>
 

--- a/kortex_description/robots/gen3_robotiq_2f_85.xacro
+++ b/kortex_description/robots/gen3_robotiq_2f_85.xacro
@@ -26,6 +26,6 @@
       use_internal_bus_gripper_comm="$(arg use_internal_bus_gripper_comm)"
       gripper_include_ros2_control="$(arg gripper_include_ros2_control)"
       gripper_com_port="$(arg gripper_com_port)">
-    </xacro:robotiq_gripper>
+    </xacro:load_robot>
 
 </robot>

--- a/kortex_description/robots/kortex_robot.xacro
+++ b/kortex_description/robots/kortex_robot.xacro
@@ -89,7 +89,6 @@
         sim_isaac="${sim_isaac}"
         isaac_joint_commands="${isaac_joint_commands}"
         isaac_joint_states="${isaac_joint_states}"
-        use_internal_bus_gripper_comm="${use_internal_bus_gripper_comm}"
         include_ros2_control="${gripper_include_ros2_control}"
         com_port="${gripper_com_port}"/>
     </xacro:unless>

--- a/kortex_description/robots/kortex_robot.xacro
+++ b/kortex_description/robots/kortex_robot.xacro
@@ -30,7 +30,6 @@
     initial_positions:=${dict(joint_1=0.0,joint_2=0.0,joint_3=0.0,joint_4=0.0,joint_5=0.0,joint_6=0.0,joint_7=0.0)}
     gripper_max_velocity:=100.0
     gripper_max_force:=100.0
-    gripper_include_ros2_control:=true
     gripper_com_port:=/dev/ttyUSB0">
 
     <!-- Include and load arm macro files -->
@@ -89,7 +88,7 @@
         sim_isaac="${sim_isaac}"
         isaac_joint_commands="${isaac_joint_commands}"
         isaac_joint_states="${isaac_joint_states}"
-        include_ros2_control="${gripper_include_ros2_control}"
+        use_internal_bus_gripper_comm="${use_internal_bus_gripper_comm}"
         com_port="${gripper_com_port}"/>
     </xacro:unless>
 

--- a/kortex_description/robots/kortex_robot.xacro
+++ b/kortex_description/robots/kortex_robot.xacro
@@ -29,7 +29,9 @@
     use_external_cable:=false
     initial_positions:=${dict(joint_1=0.0,joint_2=0.0,joint_3=0.0,joint_4=0.0,joint_5=0.0,joint_6=0.0,joint_7=0.0)}
     gripper_max_velocity:=100.0
-    gripper_max_force:=100.0">
+    gripper_max_force:=100.0
+    gripper_include_ros2_control:=true
+    gripper_com_port:=/dev/ttyUSB0">
 
     <!-- Include and load arm macro files -->
     <xacro:include filename="$(find kortex_description)/arms/${arm}/${dof}dof/urdf/${arm}_macro.xacro" />
@@ -87,7 +89,9 @@
         sim_isaac="${sim_isaac}"
         isaac_joint_commands="${isaac_joint_commands}"
         isaac_joint_states="${isaac_joint_states}"
-        use_internal_bus_gripper_comm="${use_internal_bus_gripper_comm}"/>
+        use_internal_bus_gripper_comm="${use_internal_bus_gripper_comm}"
+        include_ros2_control="${gripper_include_ros2_control}"
+        com_port="${gripper_com_port}"/>
     </xacro:unless>
 
   </xacro:macro>


### PR DESCRIPTION
Pass though more hardware parameters for gripper control:
* `use_internal_bus_gripper_comm`: specify if gripper comms will pass through the robot internally
* `(gripper_)include_ros2_control`: specify if a ros2_control instance is needed for the gripper (will be needed if we are simulating or directly communicating with the gripper via USB from the PC)
* `(gripper_)com_port`: specify the port the gripper can be exected on