### PR TITLE
Commit hash for the ros2_robotiq_gripper repository

### DIFF
--- a/ros2_kortex-not-released.humble.repos
+++ b/ros2_kortex-not-released.humble.repos
@@ -6,7 +6,7 @@ repositories:
   ros2_robotiq_gripper:
     type: git
     url: https://github.com/picknikrobotics/ros2_robotiq_gripper.git
-    version: humble
+    version: b6136bdc866a929bfb096890ca61dde1335ffd30
   serial:
     type: git
     url: https://github.com/tylerjw/serial.git

--- a/ros2_kortex.humble.repos
+++ b/ros2_kortex.humble.repos
@@ -14,4 +14,4 @@ repositories:
   ros2_robotiq_gripper:
     type: git
     url: https://github.com/picknikrobotics/ros2_robotiq_gripper.git
-    version: humble
+    version: b6136bdc866a929bfb096890ca61dde1335ffd30

--- a/ros2_kortex.repos
+++ b/ros2_kortex.repos
@@ -14,4 +14,4 @@ repositories:
   ros2_robotiq_gripper:
     type: git
     url: https://github.com/picknikrobotics/ros2_robotiq_gripper.git
-    version: humble
+    version: b6136bdc866a929bfb096890ca61dde1335ffd30


### PR DESCRIPTION
Specified a commit hash for the ros2_robotiq_gripper repository in the .repos files