### PR TITLE
update to 2.6.0 API and add support for aarch64

### DIFF
--- a/kortex_api/CMakeLists.txt
+++ b/kortex_api/CMakeLists.txt
@@ -1,13 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
 include(FetchContent)
-#include(ExternalProject)
-FetchContent_Declare(
-  kinova_binary_api
-  URL https://artifactory.kinovaapps.com:443/artifactory/generic-public/kortex/API/2.5.0/linux_x86-64_x86_gcc.zip
-  URL_HASH MD5=64bd86e7ab8bda90ef1fc7d6a356e080
-)
-
-FetchContent_MakeAvailable(kinova_binary_api)
 
 project(kortex_api)
 
@@ -18,20 +10,25 @@ project(kortex_api)
 # string(REPLACE "_" "-" URL_PROCESSOR ${CMAKE_SYSTEM_PROCESSOR}) # x86_64 -> x86-64
 # string(TOLOWER ${CMAKE_SYSTEM_NAME} URL_OS) # Linux -> linux
 
-#Current: only support Linux x86_64
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-  set(API_URL https://artifactory.kinovaapps.com:443/artifactory/generic-public/kortex/API/2.5.0/linux_x86-64_x86_gcc.zip)
+#Current: only support Linux x86_64 and aarch64
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  FetchContent_Declare(
+    kinova_binary_api
+    URL https://artifactory.kinovaapps.com:443/artifactory/generic-public/kortex/API/2.6.0/linux_aarch64_gcc_7.4.zip
+    URL_HASH MD5=d7771a7c106888717ace359164d40235
+  )
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  FetchContent_Declare(
+    kinova_binary_api
+    URL https://artifactory.kinovaapps.com:443/artifactory/generic-public/kortex/API/2.6.0/linux_x86-64_x86_gcc.zip
+    URL_HASH MD5=9d787a0f5405f02031db1e01dffa408f
+  )
 else()
   set(API_URL "")
-  message(FATAL_ERROR "Unsupported System: currently support is for Linux x68_64. Detected ${CMAKE_SYSTEM_NAME} and ${CMAKE_SYSTEM_PROCESSOR}")
+  message(FATAL_ERROR "Unsupported System: currently support is for Linux x68_64 or aarch64. Detected ${CMAKE_SYSTEM_NAME} and ${CMAKE_SYSTEM_PROCESSOR}")
 endif()
 
-#ExternalProject_Add(kinova_binary_api
-#  URL ${API_URL}
-#  CONFIGURE_COMMAND ""
-#  BUILD_COMMAND ""
-#  INSTALL_COMMAND ""
-#)
+FetchContent_MakeAvailable(kinova_binary_api)
 
 find_package(ament_cmake REQUIRED)
 

--- a/kortex_driver/CMakeLists.txt
+++ b/kortex_driver/CMakeLists.txt
@@ -1,11 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
 include(FetchContent)
-FetchContent_Declare(
-  kinova_binary_api
-  URL https://artifactory.kinovaapps.com:443/artifactory/generic-public/kortex/API/2.5.0/linux_x86-64_x86_gcc.zip
-  URL_HASH MD5=64bd86e7ab8bda90ef1fc7d6a356e080
-)
-FetchContent_MakeAvailable(kinova_binary_api)
 
 project(kortex_driver)
 
@@ -28,15 +22,27 @@ find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(kortex_api REQUIRED)
 
-#Current: only support Linux x86_64
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-  set(API_URL https://artifactory.kinovaapps.com:443/artifactory/generic-public/kortex/API/2.5.0/linux_x86-64_x86_gcc.zip)
+#Current: only support Linux x86_64 and aarch64
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  FetchContent_Declare(
+    kinova_binary_api
+    URL https://artifactory.kinovaapps.com:443/artifactory/generic-public/kortex/API/2.6.0/linux_aarch64_gcc_7.4.zip
+    URL_HASH MD5=d7771a7c106888717ace359164d40235
+  )
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  FetchContent_Declare(
+    kinova_binary_api
+    URL https://artifactory.kinovaapps.com:443/artifactory/generic-public/kortex/API/2.6.0/linux_x86-64_x86_gcc.zip
+    URL_HASH MD5=9d787a0f5405f02031db1e01dffa408f
+  )
 else()
   # TODO(future) to support ARM or other builds logic could go here to fetch the precompiled libKortexApiCpp.a
   # see notes in kortex_api CMakeList.txt
   message(WARNING "Detected ${CMAKE_SYSTEM_NAME} and ${CMAKE_SYSTEM_PROCESSOR}")
-  message(FATAL_ERROR "Unsupported System: currently support is for Linux x68_64.")
+  message(FATAL_ERROR "Unsupported System: currently support is for Linux x68_64 or aarch64.")
 endif()
+
+FetchContent_MakeAvailable(kinova_binary_api)
 
 # CMake does not allow IMPORTED libraries to be installed
 # The package kortex_api will download and setup the include directories


### PR DESCRIPTION
This PR adds support for `aarch64` systems, in addition to the existing `x86_64`.