### PR TITLE
Added the empty gripper option for gen3.launch.py

### DIFF
--- a/kortex_bringup/launch/gen3.launch.py
+++ b/kortex_bringup/launch/gen3.launch.py
@@ -71,9 +71,9 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "gripper",
-            default_value="robotiq_2f_85",
+            default_value="",
             description="Name of the gripper attached to the arm",
-            choices=["robotiq_2f_85", "robotiq_2f_140"],
+            choices=["", "robotiq_2f_85", "robotiq_2f_140"],
         )
     )
     declared_arguments.append(

--- a/kortex_bringup/launch/kortex_control.launch.py
+++ b/kortex_bringup/launch/kortex_control.launch.py
@@ -27,6 +27,7 @@ from launch.substitutions import (
     FindExecutable,
     LaunchConfiguration,
     PathJoinSubstitution,
+    PythonExpression,
 )
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
@@ -187,7 +188,11 @@ def launch_setup(context, *args, **kwargs):
         package="controller_manager",
         executable="spawner",
         arguments=[robot_hand_controller, "-c", "/controller_manager"],
-        condition=UnlessCondition(is_gen3_lite),
+        condition=IfCondition(
+            PythonExpression([
+                "'", gripper, "' != '' and '", is_gen3_lite, "' == 'false'"
+            ])
+        ),
     )
 
     # only start the fault controller if we are using hardware
@@ -205,9 +210,14 @@ def launch_setup(context, *args, **kwargs):
         delay_rviz_after_joint_state_broadcaster_spawner,
         robot_traj_controller_spawner,
         robot_pos_controller_spawner,
-        robot_hand_controller_spawner,
         fault_controller_spawner,
     ]
+    start_robot_hand_controller = (
+        gripper.perform(context) != "" and is_gen3_lite != "true"
+    )
+    # Conditionally add robot_hand_controller_spawner
+    if start_robot_hand_controller:
+        nodes_to_start.append(robot_hand_controller_spawner)
 
     return nodes_to_start
 
@@ -304,7 +314,7 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "gripper",
-            default_value='""',
+            default_value="",
             description="Name of the gripper attached to the arm",
         )
     )

--- a/kortex_bringup/launch/kortex_control.launch.py
+++ b/kortex_bringup/launch/kortex_control.launch.py
@@ -21,7 +21,7 @@ from launch.actions import (
     RegisterEventHandler,
 )
 from launch.event_handlers import OnProcessExit
-from launch.conditions import IfCondition, UnlessCondition
+from launch.conditions import IfCondition
 from launch.substitutions import (
     Command,
     FindExecutable,
@@ -189,9 +189,7 @@ def launch_setup(context, *args, **kwargs):
         executable="spawner",
         arguments=[robot_hand_controller, "-c", "/controller_manager"],
         condition=IfCondition(
-            PythonExpression([
-                "'", gripper, "' != '' and '", is_gen3_lite, "' == 'false'"
-            ])
+            PythonExpression(["'", gripper, "' != '' and '", is_gen3_lite, "' == 'false'"])
         ),
     )
 
@@ -212,9 +210,7 @@ def launch_setup(context, *args, **kwargs):
         robot_pos_controller_spawner,
         fault_controller_spawner,
     ]
-    start_robot_hand_controller = (
-        gripper.perform(context) != "" and is_gen3_lite != "true"
-    )
+    start_robot_hand_controller = gripper.perform(context) != "" and is_gen3_lite != "true"
     # Conditionally add robot_hand_controller_spawner
     if start_robot_hand_controller:
         nodes_to_start.append(robot_hand_controller_spawner)

--- a/kortex_description/robots/gen3.xacro
+++ b/kortex_description/robots/gen3.xacro
@@ -13,7 +13,7 @@
     <xacro:arg name="port_realtime" default="10001" />
     <xacro:arg name="session_inactivity_timeout_ms" default="60000" />
     <xacro:arg name="connection_inactivity_timeout_ms" default="2000" />
-    <xacro:arg name="gripper" default="robotiq_2f_85" />
+    <xacro:arg name="gripper" default="" />
     <xacro:arg name="gripper_joint_name" default="finger_joint" />
     <xacro:arg name="gripper_max_velocity" default="100.0" />
     <xacro:arg name="gripper_max_force" default="100.0" />


### PR DESCRIPTION
This feature allows to launch then gen3.launch.py without any mounted gripper.