### PR TITLE
updated gen3 lite moveit config w/ arm & gripper groups

### DIFF
--- a/kortex_description/arms/gen3_lite/6dof/config/ros2_controllers.yaml
+++ b/kortex_description/arms/gen3_lite/6dof/config/ros2_controllers.yaml
@@ -31,7 +31,7 @@ joint_trajectory_controller:
       - velocity
     state_publish_rate: 100.0
     action_monitor_rate: 20.0
-    allow_partial_joints_goal: false
+    allow_partial_joints_goal: ture
     constraints:
       stopped_velocity_tolerance: 0.0
       goal_time: 0.0

--- a/kortex_description/arms/gen3_lite/6dof/config/ros2_controllers.yaml
+++ b/kortex_description/arms/gen3_lite/6dof/config/ros2_controllers.yaml
@@ -31,7 +31,7 @@ joint_trajectory_controller:
       - velocity
     state_publish_rate: 100.0
     action_monitor_rate: 20.0
-    allow_partial_joints_goal: ture
+    allow_partial_joints_goal: true
     constraints:
       stopped_velocity_tolerance: 0.0
       goal_time: 0.0

--- a/kortex_moveit_config/kinova_gen3_lite_moveit_config/config/gen3_lite.srdf
+++ b/kortex_moveit_config/kinova_gen3_lite_moveit_config/config/gen3_lite.srdf
@@ -10,16 +10,45 @@
     <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
     <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
     <group name="gen3_lite_arm">
+        <joint name="base_joint"/>
         <joint name="joint_1"/>
         <joint name="joint_2"/>
         <joint name="joint_3"/>
         <joint name="joint_4"/>
         <joint name="joint_5"/>
         <joint name="joint_6"/>
+        <joint name="end_effector"/>
+    </group>
+    <group name="gen3_lite_gripper">
+        <joint name="gripper_base_joint"/>
+        <joint name="left_finger_bottom_joint"/>
         <joint name="right_finger_bottom_joint"/>
     </group>
+    <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
+    <group_state name="vertical" group="gen3_lite_arm">
+        <joint name="joint_1" value="0"/>
+        <joint name="joint_2" value="0"/>
+        <joint name="joint_3" value="0"/>
+        <joint name="joint_4" value="0"/>
+        <joint name="joint_5" value="0"/>
+        <joint name="joint_6" value="0"/>
+    </group_state>
+    <group_state name="home" group="gen3_lite_arm">
+        <joint name="joint_1" value="0"/>
+        <joint name="joint_2" value="0.2229"/>
+        <joint name="joint_3" value="2.6306"/>
+        <joint name="joint_4" value="-1.5707"/>
+        <joint name="joint_5" value="-0.355"/>
+        <joint name="joint_6" value="1.5707"/>
+    </group_state>
+    <group_state name="open" group="gen3_lite_gripper">
+        <joint name="right_finger_bottom_joint" value="0"/>
+    </group_state>
+    <group_state name="closed" group="gen3_lite_gripper">
+        <joint name="right_finger_bottom_joint" value="0.775"/>
+    </group_state>
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
-    <end_effector name="gen3_lite_gripper" parent_link="end_effector_link" group="gen3_lite_arm"/>
+    <end_effector name="gen3_lite_gripper" parent_link="end_effector_link" group="gen3_lite_gripper"/>
     <!--PASSIVE JOINT: Purpose: this element is used to mark joints that are not actuated-->
     <passive_joint name="left_finger_bottom_joint"/>
     <passive_joint name="left_finger_tip_joint"/>
@@ -46,7 +75,6 @@
     <disable_collisions link1="gripper_base_link" link2="upper_wrist_link" reason="Adjacent"/>
     <disable_collisions link1="left_finger_dist_link" link2="left_finger_prox_link" reason="Adjacent"/>
     <disable_collisions link1="left_finger_dist_link" link2="lower_wrist_link" reason="Never"/>
-    <disable_collisions link1="left_finger_dist_link" link2="right_finger_dist_link" reason="User"/>
     <disable_collisions link1="left_finger_dist_link" link2="right_finger_prox_link" reason="Never"/>
     <disable_collisions link1="left_finger_dist_link" link2="upper_wrist_link" reason="Never"/>
     <disable_collisions link1="left_finger_prox_link" link2="lower_wrist_link" reason="Never"/>

--- a/kortex_moveit_config/kinova_gen3_lite_moveit_config/config/kinematics.yaml
+++ b/kortex_moveit_config/kinova_gen3_lite_moveit_config/config/kinematics.yaml
@@ -2,3 +2,7 @@ gen3_lite_arm:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.0050000000000000001
   kinematics_solver_timeout: 0.0050000000000000001
+gen3_lite_gripper:
+  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+  kinematics_solver_search_resolution: 0.0050000000000000001
+  kinematics_solver_timeout: 0.0050000000000000001


### PR DESCRIPTION
This pull request is to separate Gen3 Lite MoveIt2 planning groups between the arm and gripper to allow for easier usage.
This pr addresses [issue 249](https://github.com/Kinovarobotics/ros2_kortex/issues/249).

Created different MoveIt2 motion planning groups to separate arm and gripper planning.
Created saved group_states for arm:vertical, arm:home, gripper:open, and gripper:closed like ros1.
The new planning group requires the additional gripper group in `kinematics.yaml`.
Since both groups use the joint_trajectory_controller, the `allow_partial_joint_goals` parameter needs to be `true` in `ros2_controllers.yaml` to allow them to move independently. 
Tested with:

```bash
ros2 launch kortex_bringup kortex_sim_control.launch.py sim_ignition:=false sim_gazebo:=true robot_type:=gen3_lite robot_name:=gen3_lite dof:=6 gripper:=gen3_lite_2f launch_rviz:=false
```

```bash
ros2 launch kinova_gen3_lite_moveit_config sim.launch.py 
```

![Screenshot from 2024-10-31 18-00-40](https://github.com/user-attachments/assets/32770330-921d-4d5c-8e2d-aea356dde56c)
