### PR TITLE
replaced file:// to package:// in gen3_lite xacro

### DIFF
--- a/kortex_description/grippers/gen3_lite_2f/urdf/gen3_lite_2f_macro.xacro
+++ b/kortex_description/grippers/gen3_lite_2f/urdf/gen3_lite_2f_macro.xacro
@@ -64,7 +64,7 @@
         <visual>
           <origin xyz="0 0 0" rpy="0 0 0" />
           <geometry>
-            <mesh filename="file://$(find kortex_description)/grippers/gen3_lite_2f/meshes/gripper_base_link.STL" />
+            <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/gripper_base_link.STL" />
           </geometry>
           <material name="">
             <color rgba="0.803 0.824 0.820 1" />
@@ -73,7 +73,7 @@
         <collision>
           <origin xyz="0 0 0" rpy="0 0 0" />
           <geometry>
-            <mesh filename="file://$(find kortex_description)/grippers/gen3_lite_2f/meshes/gripper_base_link.STL" />
+            <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/gripper_base_link.STL" />
           </geometry>
         </collision>
       </link>
@@ -90,7 +90,7 @@
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="file://$(find kortex_description)/grippers/gen3_lite_2f/meshes/right_finger_prox_link.STL" />
+          <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/right_finger_prox_link.STL" />
         </geometry>
         <material name="">
             <color rgba="0.803 0.824 0.820 1" />
@@ -99,7 +99,7 @@
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="file://$(find kortex_description)/grippers/gen3_lite_2f/meshes/right_finger_prox_link.STL" />
+          <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/right_finger_prox_link.STL" />
         </geometry>
       </collision>
       </link>
@@ -123,7 +123,7 @@
         <visual>
           <origin xyz="0 0 0" rpy="0 0 0" />
           <geometry>
-            <mesh filename="file://$(find kortex_description)/grippers/gen3_lite_2f/meshes/right_finger_dist_link.STL" />
+            <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/right_finger_dist_link.STL" />
           </geometry>
           <material name="">
             <color rgba="0 0.055 0.525 1" />
@@ -132,7 +132,7 @@
         <collision>
           <origin xyz="0 0 0" rpy="0 0 0" />
           <geometry>
-            <mesh filename="file://$(find kortex_description)/grippers/gen3_lite_2f/meshes/right_finger_dist_link.STL" />
+            <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/right_finger_dist_link.STL" />
           </geometry>
         </collision>
       </link>
@@ -156,7 +156,7 @@
         <visual>
           <origin xyz="0 0 0" rpy="0 0 0" />
           <geometry>
-            <mesh filename="file://$(find kortex_description)/grippers/gen3_lite_2f/meshes/left_finger_prox_link.STL" />
+            <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/left_finger_prox_link.STL" />
           </geometry>
           <material name="">
             <color rgba="0.803 0.824 0.820 1" />
@@ -165,7 +165,7 @@
         <collision>
           <origin xyz="0 0 0" rpy="0 0 0" />
           <geometry>
-            <mesh filename="file://$(find kortex_description)/grippers/gen3_lite_2f/meshes/left_finger_prox_link.STL" />
+            <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/left_finger_prox_link.STL" />
           </geometry>
         </collision>
       </link>
@@ -189,7 +189,7 @@
         <visual>
           <origin xyz="0 0 0" rpy="0 0 0" />
           <geometry>
-            <mesh filename="file://$(find kortex_description)/grippers/gen3_lite_2f/meshes/left_finger_dist_link.STL" />
+            <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/left_finger_dist_link.STL" />
           </geometry>
           <material name="">
             <color rgba="0 0.055 0.525 1" />
@@ -198,7 +198,7 @@
         <collision>
           <origin xyz="0 0 0" rpy="0 0 0" />
           <geometry>
-            <mesh filename="file://$(find kortex_description)/grippers/gen3_lite_2f/meshes/left_finger_dist_link.STL" />
+            <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/left_finger_dist_link.STL" />
           </geometry>
         </collision>
       </link>
@@ -243,7 +243,7 @@
         <visual>
           <origin xyz="0 0 0" rpy="0 0 0" />
           <geometry>
-            <mesh filename="file://$(find kortex_description)/grippers/gen3_lite_2f/meshes/gripper_base_link.STL" />
+            <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/gripper_base_link.STL" />
           </geometry>
           <material name="">
             <color rgba="0.803 0.824 0.820 1" />
@@ -252,7 +252,7 @@
         <collision>
           <origin xyz="0 0 0" rpy="0 0 0" />
           <geometry>
-            <mesh filename="file://$(find kortex_description)/grippers/gen3_lite_2f/meshes/gripper_base_link.STL" />
+            <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/gripper_base_link.STL" />
           </geometry>
         </collision>
       </link>
@@ -269,7 +269,7 @@
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="file://$(find kortex_description)/grippers/gen3_lite_2f/meshes/right_finger_prox_link.STL" />
+          <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/right_finger_prox_link.STL" />
         </geometry>
         <material name="">
             <color rgba="0.803 0.824 0.820 1" />
@@ -278,7 +278,7 @@
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="file://$(find kortex_description)/grippers/gen3_lite_2f/meshes/right_finger_prox_link.STL" />
+          <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/right_finger_prox_link.STL" />
         </geometry>
       </collision>
       </link>
@@ -302,7 +302,7 @@
         <visual>
           <origin xyz="0 0 0" rpy="0 0 0" />
           <geometry>
-            <mesh filename="file://$(find kortex_description)/grippers/gen3_lite_2f/meshes/right_finger_dist_link.STL" />
+            <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/right_finger_dist_link.STL" />
           </geometry>
           <material name="">
             <color rgba="0 0.055 0.525 1" />
@@ -311,7 +311,7 @@
         <collision>
           <origin xyz="0 0 0" rpy="0 0 0" />
           <geometry>
-            <mesh filename="file://$(find kortex_description)/grippers/gen3_lite_2f/meshes/right_finger_dist_link.STL" />
+            <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/right_finger_dist_link.STL" />
           </geometry>
         </collision>
       </link>
@@ -336,7 +336,7 @@
         <visual>
           <origin xyz="0 0 0" rpy="0 0 0" />
           <geometry>
-            <mesh filename="file://$(find kortex_description)/grippers/gen3_lite_2f/meshes/left_finger_prox_link.STL" />
+            <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/left_finger_prox_link.STL" />
           </geometry>
           <material name="">
             <color rgba="0.803 0.824 0.820 1" />
@@ -345,7 +345,7 @@
         <collision>
           <origin xyz="0 0 0" rpy="0 0 0" />
           <geometry>
-            <mesh filename="file://$(find kortex_description)/grippers/gen3_lite_2f/meshes/left_finger_prox_link.STL" />
+            <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/left_finger_prox_link.STL" />
           </geometry>
         </collision>
       </link>
@@ -369,7 +369,7 @@
         <visual>
           <origin xyz="0 0 0" rpy="0 0 0" />
           <geometry>
-            <mesh filename="file://$(find kortex_description)/grippers/gen3_lite_2f/meshes/left_finger_dist_link.STL" />
+            <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/left_finger_dist_link.STL" />
           </geometry>
           <material name="">
             <color rgba="0 0.055 0.525 1" />
@@ -378,7 +378,7 @@
         <collision>
           <origin xyz="0 0 0" rpy="0 0 0" />
           <geometry>
-            <mesh filename="file://$(find kortex_description)/grippers/gen3_lite_2f/meshes/left_finger_dist_link.STL" />
+            <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/left_finger_dist_link.STL" />
           </geometry>
         </collision>
       </link>


### PR DESCRIPTION
This is to make the robot description work with multiple computers in network. Absolute path by file:// in one computer is not same as in another computer in the network.