### PR TITLE
Added prefix to robotiq gripper names to allow multiple gripper spawning

### DIFF
--- a/kortex_description/grippers/robotiq_2f_140/urdf/robotiq_2f_140_macro.xacro
+++ b/kortex_description/grippers/robotiq_2f_140/urdf/robotiq_2f_140_macro.xacro
@@ -21,7 +21,7 @@
     </xacro:if>
 
     <xacro:robotiq_gripper
-        name="RobotiqGripperHardwareInterface"
+        name="${prefix}RobotiqGripperHardwareInterface"
         prefix="${prefix}"
         parent="${parent}"
         include_ros2_control="${include_ros2_control}"

--- a/kortex_description/grippers/robotiq_2f_85/urdf/robotiq_2f_85_macro.xacro
+++ b/kortex_description/grippers/robotiq_2f_85/urdf/robotiq_2f_85_macro.xacro
@@ -21,7 +21,7 @@
     </xacro:if>
 
     <xacro:robotiq_gripper
-        name="RobotiqGripperHardwareInterface"
+        name="${prefix}RobotiqGripperHardwareInterface"
         prefix="${prefix}"
         parent="${parent}"
         include_ros2_control="${include_ros2_control}"


### PR DESCRIPTION
When trying to spawn multiple arms, for example, a bimanual setup, similar to the official moveit dual arms example (https://moveit.picknik.ai/main/doc/examples/dual_arms/dual_arms_tutorial.html), I encountered the following error:

```
[ros2_control_node-4] [ERROR] [1747138663.449760301] [controller_manager]: The published robot description file (urdf) seems not to be genuine. The following error was caught:Hardware name RobotiqGripperHardwareInterface is duplicated. Please provide a unique 'name' in the URDF.
```

After adding the prefix for robotiq gripper name in xacro include parameters, both gripper were loaded successfully:

```
[ros2_control_node-4] [INFO] [resource_manager]: Loading hardware 'left_RobotiqGripperHardwareInterface'
[ros2_control_node-4] [INFO] [resource_manager]: Initialize hardware 'left_RobotiqGripperHardwareInterface'  
[ros2_control_node-4] [INFO] [resource_manager]: Successful initialization of hardware 'left_RobotiqGripperHardwareInterface'  
[ros2_control_node-4] [INFO] [resource_manager]: 'configure' hardware 'left_RobotiqGripperHardwareInterface'  
[ros2_control_node-4] [INFO] [resource_manager]: Successful 'configure' of hardware 'left_RobotiqGripperHardwareInterface'  
[ros2_control_node-4] [INFO] [resource_manager]: 'activate' hardware 'left_RobotiqGripperHardwareInterface'  
[ros2_control_node-4] [INFO] [resource_manager]: Successful 'activate' of hardware 'left_RobotiqGripperHardwareInterface'  
[ros2_control_node-4] [INFO] [resource_manager]: Loading hardware 'right_RobotiqGripperHardwareInterface'  
[ros2_control_node-4] [INFO] [resource_manager]: Initialize hardware 'right_RobotiqGripperHardwareInterface'  
[ros2_control_node-4] [INFO] [resource_manager]: Successful initialization of hardware 'right_RobotiqGripperHardwareInterface'  
[ros2_control_node-4] [INFO] [resource_manager]: 'configure' hardware 'right_RobotiqGripperHardwareInterface'  
[ros2_control_node-4] [INFO] [resource_manager]: Successful 'configure' of hardware 'right_RobotiqGripperHardwareInterface'  
[ros2_control_node-4] [INFO] [resource_manager]: 'activate' hardware 'right_RobotiqGripperHardwareInterface'  
[ros2_control_node-4] [INFO] [resource_manager]: Successful 'activate' of hardware 'right_RobotiqGripperHardwareInterface'  
```