### PR TITLE
Fix `mock_sensor_commands` variable name for Robotiq macro on Humble

### DIFF
--- a/kortex_description/grippers/robotiq_2f_140/urdf/robotiq_2f_140_macro.xacro
+++ b/kortex_description/grippers/robotiq_2f_140/urdf/robotiq_2f_140_macro.xacro
@@ -27,7 +27,7 @@
         include_ros2_control="${include_ros2_control}"
         com_port="${com_port}"
         use_fake_hardware="${use_fake_hardware}"
-        fake_sensor_commands="${fake_sensor_commands}"
+        mock_sensor_commands="${fake_sensor_commands}"
         sim_ignition="${sim_ignition}"
         sim_isaac="${sim_isaac}"
         isaac_joint_commands="${isaac_joint_commands}"

--- a/kortex_description/grippers/robotiq_2f_85/urdf/robotiq_2f_85_macro.xacro
+++ b/kortex_description/grippers/robotiq_2f_85/urdf/robotiq_2f_85_macro.xacro
@@ -27,7 +27,7 @@
         include_ros2_control="${include_ros2_control}"
         com_port="${com_port}"
         use_fake_hardware="${use_fake_hardware}"
-        fake_sensor_commands="${fake_sensor_commands}"
+        mock_sensor_commands="${fake_sensor_commands}"
         sim_ignition="${sim_ignition}"
         sim_isaac="${sim_isaac}"
         isaac_joint_commands="${isaac_joint_commands}"


### PR DESCRIPTION
The `ros2_robotiq_gripper` repo on Humble uses `mock_sensor_commands` as its macro name, so this fixes things.

source: 
* https://github.com/PickNikRobotics/ros2_robotiq_gripper/blob/e5656b1c1926864899dfb133dc68d483cfb1d9cc/robotiq_description/urdf/robotiq_2f_85_macro.urdf.xacro#L13
* https://github.com/PickNikRobotics/ros2_robotiq_gripper/blob/e5656b1c1926864899dfb133dc68d483cfb1d9cc/robotiq_description/urdf/robotiq_2f_140_macro.urdf.xacro#L13