### PR TITLE
add missing params in urdf (vision, prefix for gripper joint name)

### DIFF
--- a/kortex_bringup/launch/gen3.launch.py
+++ b/kortex_bringup/launch/gen3.launch.py
@@ -63,6 +63,13 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
+            "vision",
+            default_value="false",
+            description="Is vision module (camera) present on the robot?",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
             "controllers_file",
             default_value="ros2_controllers.yaml",
             description="Robot controller to start.",
@@ -115,6 +122,7 @@ def generate_launch_description():
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
     fake_sensor_commands = LaunchConfiguration("fake_sensor_commands")
     robot_controller = LaunchConfiguration("robot_controller")
+    vision = LaunchConfiguration("vision")
     gripper = LaunchConfiguration("gripper")
     use_internal_bus_gripper_comm = LaunchConfiguration("use_internal_bus_gripper_comm")
     gripper_max_velocity = LaunchConfiguration("gripper_max_velocity")
@@ -132,6 +140,7 @@ def generate_launch_description():
             "use_fake_hardware": use_fake_hardware,
             "fake_sensor_commands": fake_sensor_commands,
             "robot_controller": robot_controller,
+            "vision": vision,
             "gripper": gripper,
             "use_internal_bus_gripper_comm": use_internal_bus_gripper_comm,
             "gripper_max_velocity": gripper_max_velocity,

--- a/kortex_bringup/launch/kortex_control.launch.py
+++ b/kortex_bringup/launch/kortex_control.launch.py
@@ -44,6 +44,7 @@ def launch_setup(context, *args, **kwargs):
     description_file = LaunchConfiguration("description_file")
     robot_name = LaunchConfiguration("robot_name")
     prefix = LaunchConfiguration("prefix")
+    vision = LaunchConfiguration("vision")
     gripper = LaunchConfiguration("gripper")
     gripper_max_velocity = LaunchConfiguration("gripper_max_velocity")
     gripper_max_force = LaunchConfiguration("gripper_max_force")
@@ -59,7 +60,7 @@ def launch_setup(context, *args, **kwargs):
 
     # if we are using fake hardware then we can't use the internal gripper communications of the hardware
     use_fake_hardware_value = use_fake_hardware.perform(context)
-    if use_fake_hardware_value == "true":
+    if use_fake_hardware_value == "true" or gripper.perform(context) == "":
         use_internal_bus_gripper_comm = "false"
 
     robot_description_content = Command(
@@ -90,6 +91,9 @@ def launch_setup(context, *args, **kwargs):
             " ",
             "fake_sensor_commands:=",
             fake_sensor_commands,
+            " ",
+            "vision:=",
+            vision,
             " ",
             "gripper:=",
             gripper,
@@ -298,6 +302,13 @@ def generate_launch_description():
             description="Prefix of the joint names, useful for \
         multi-robot setup. If changed than also joint names in the controllers' configuration \
         have to be updated.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "vision",
+            default_value="false",
+            description="Is vision module (camera) present on the robot?", 
         )
     )
     declared_arguments.append(

--- a/kortex_description/arms/gen3/6dof/urdf/kortex.ros2_control.xacro
+++ b/kortex_description/arms/gen3/6dof/urdf/kortex.ros2_control.xacro
@@ -51,7 +51,7 @@
           <param name="connection_inactivity_timeout_ms">${connection_inactivity_timeout_ms}</param>
           <param name="tf_prefix">"${tf_prefix}"</param>
           <param name="use_internal_bus_gripper_comm">${use_internal_bus_gripper_comm}</param>
-          <param name="gripper_joint_name">${gripper_joint_name}</param>
+          <param name="gripper_joint_name">${prefix}${gripper_joint_name}</param>
           <param name="gripper_max_velocity">${gripper_max_velocity}</param>
           <param name="gripper_max_force">${gripper_max_force}</param>
         </xacro:unless>

--- a/kortex_description/arms/gen3/7dof/urdf/kortex.ros2_control.xacro
+++ b/kortex_description/arms/gen3/7dof/urdf/kortex.ros2_control.xacro
@@ -51,7 +51,7 @@
           <param name="connection_inactivity_timeout_ms">${connection_inactivity_timeout_ms}</param>
           <param name="tf_prefix">"${tf_prefix}"</param>
           <param name="use_internal_bus_gripper_comm">${use_internal_bus_gripper_comm}</param>
-          <param name="gripper_joint_name">${gripper_joint_name}</param>
+          <param name="gripper_joint_name">${prefix}${gripper_joint_name}</param>
           <param name="gripper_max_velocity">${gripper_max_velocity}</param>
           <param name="gripper_max_force">${gripper_max_force}</param>
         </xacro:unless>


### PR DESCRIPTION
following changes were made:
  1. missing vision param for gen3 arms
  2. missing prefix for gripper_joint_name in ros2_control 
  3. missing gripper check in kortex_control.launch