### PR TITLE
Fix deprecated hardware_interface API

### DIFF
--- a/kortex_driver/include/kortex_driver/hardware_interface.hpp
+++ b/kortex_driver/include/kortex_driver/hardware_interface.hpp
@@ -84,7 +84,7 @@ public:
   RCLCPP_SHARED_PTR_DEFINITIONS(KortexMultiInterfaceHardware);
 
   KORTEX_DRIVER_PUBLIC
-  CallbackReturn on_init(const hardware_interface::HardwareInfo & info) final;
+  CallbackReturn on_init(const hardware_interface::HardwareComponentInterfaceParams & params) final;
 
   KORTEX_DRIVER_PUBLIC
   std::vector<hardware_interface::StateInterface> export_state_interfaces() final;

--- a/kortex_driver/src/hardware_interface.cpp
+++ b/kortex_driver/src/hardware_interface.cpp
@@ -93,7 +93,7 @@ CallbackReturn KortexMultiInterfaceHardware::on_init(
     return CallbackReturn::ERROR;
   }
 
-  info_ = info;
+  info_ = params.hardware_info;
   // The robot's IP address.
   std::string robot_ip = info_.hardware_parameters["robot_ip"];
   if (robot_ip.empty())

--- a/kortex_driver/src/hardware_interface.cpp
+++ b/kortex_driver/src/hardware_interface.cpp
@@ -84,10 +84,11 @@ KortexMultiInterfaceHardware::KortexMultiInterfaceHardware()
   }
 }
 
-CallbackReturn KortexMultiInterfaceHardware::on_init(const hardware_interface::HardwareInfo & info)
+CallbackReturn KortexMultiInterfaceHardware::on_init(
+  const hardware_interface::HardwareComponentInterfaceParams & params)
 {
   RCLCPP_INFO(LOGGER, "Configuring Hardware Interface");
-  if (hardware_interface::SystemInterface::on_init(info) != CallbackReturn::SUCCESS)
+  if (hardware_interface::SystemInterface::on_init(params) != CallbackReturn::SUCCESS)
   {
     return CallbackReturn::ERROR;
   }


### PR DESCRIPTION
See https://github.com/ros-controls/ros2_control/pull/2323
needed for https://github.com/ros-controls/ros2_control/pull/2589

Please release it to kilted and rolling, thanks :)
Note: This API is not available on humble.