### PR TITLE
Add gripper parameter

### DIFF
--- a/kortex_description/arms/gen3_lite/6dof/urdf/gen3_lite_macro.xacro
+++ b/kortex_description/arms/gen3_lite/6dof/urdf/gen3_lite_macro.xacro
@@ -19,6 +19,7 @@
     session_inactivity_timeout_ms:=6000
     connection_inactivity_timeout_ms:=2000
     use_internal_bus_gripper_comm:=true
+    gripper:=gen3_lite_2f 
     gripper_joint_name
     gripper_max_velocity:=100.0
     gripper_max_force:=100.0


### PR DESCRIPTION
# Pull Request

## Summary
Add missing gripper parameter configuration to kortex_description/arms/gen3_lite/6dof/urdf/gen3_lite_macro.xacro.

## Changes
Add gripper parameter to enable the gen3_lite gripper.

## Related Issues
Fix gen3_lite failure issue caused by missing gripper parameter.
